### PR TITLE
Fix-camelcase-issue-on-error-responses

### DIFF
--- a/.changeset/cyan-parrots-wonder.md
+++ b/.changeset/cyan-parrots-wonder.md
@@ -1,5 +1,0 @@
----
-"@baseapp-frontend/core": minor
----
-
-Adding cammelcase on error responses

--- a/.changeset/cyan-parrots-wonder.md
+++ b/.changeset/cyan-parrots-wonder.md
@@ -1,0 +1,5 @@
+---
+"@baseapp-frontend/core": minor
+---
+
+Adding cammelcase on error responses

--- a/.changeset/slimy-rats-smoke.md
+++ b/.changeset/slimy-rats-smoke.md
@@ -1,0 +1,5 @@
+---
+"@baseapp-frontend/core": minor
+---
+
+Adding cammelcase on axios error responses and option to send query param to the redirectTo route on useUser

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -83,6 +83,9 @@ const { user, isLoading } = useUser({redirectTo: '/auth/login', redirectIfFound:
 	 - Optional, defaults to `false`
 	 - if `true` will redirect if the users is logged in
 	 - if `false` will redirect if logged out
+ - `query`
+   - Optional
+   - query params you can pass to the redirectTo route 
 
 ### Returns
 

--- a/packages/core/src/auth/login.tsx
+++ b/packages/core/src/auth/login.tsx
@@ -21,11 +21,16 @@ import type {
   ILoginMfaRequest,
   ILoginMfaResponse,
   ILoginResponse,
+  IUseUser,
   IUserContext,
   LoginRequiredServerSideProps,
 } from './types'
 
-export function useUser({ redirectTo = '', redirectIfFound = false } = {}): IUserContext {
+export function useUser({
+  redirectTo = '',
+  redirectIfFound = false,
+  query = {},
+}: IUseUser = {}): IUserContext {
   const router = useRouter()
   const { user, isLoading, isSuccess, isIdle, status, setUser, refetchUser } = useUserContext()
 
@@ -40,7 +45,10 @@ export function useUser({ redirectTo = '', redirectIfFound = false } = {}): IUse
       // If redirectIfFound is also set, redirect if the user was found
       (redirectIfFound && user)
     ) {
-      router.push(redirectTo)
+      router.push({
+        pathname: redirectTo,
+        query,
+      })
     }
   }, [user, redirectIfFound, redirectTo, isLoading])
 

--- a/packages/core/src/auth/provider.tsx
+++ b/packages/core/src/auth/provider.tsx
@@ -52,3 +52,8 @@ export const BaseAppProvider = ({
     </QueryClientProvider>
   )
 }
+
+BaseAppProvider.defaultProps = {
+  pageProps: {},
+  queryClientOptions: {},
+}

--- a/packages/core/src/auth/types.d.ts
+++ b/packages/core/src/auth/types.d.ts
@@ -84,6 +84,12 @@ export interface IResetPassword {
   mutation: UseMutationResult<unknown, unknown, void, unknown>
 }
 
+export interface IUseUser {
+  redirectTo?: string
+  redirectIfFound?: boolean
+  query?: Record<string, string>
+}
+
 export interface IUserContext {
   user: IUser | null
   isLoading: boolean

--- a/packages/core/src/axios.ts
+++ b/packages/core/src/axios.ts
@@ -37,12 +37,21 @@ function createAxiosInstance(file = false) {
     return request
   })
 
-  instance.interceptors.response.use((response) => {
-    if (response.data && response.headers?.['content-type'] === 'application/json') {
-      response.data = humps.camelizeKeys(response.data)
-    }
-    return response
-  })
+  instance.interceptors.response.use(
+    (response) => {
+      if (response.data && response.headers?.['content-type'] === 'application/json') {
+        response.data = humps.camelizeKeys(response.data)
+      }
+      return response
+    },
+    (error) => {
+      if (error.response.data && error.response.headers?.['content-type'] === 'application/json') {
+        const newError = { response: { data: {} } }
+        newError.response.data = humps.camelizeKeys(error.response.data)
+      }
+      return Promise.reject(error)
+    },
+  )
 
   return instance
 }

--- a/packages/core/src/storage/useLocalStorage.ts
+++ b/packages/core/src/storage/useLocalStorage.ts
@@ -23,7 +23,7 @@ export function useLocalStorage<T>(
       return item ? JSON.parse(item) : initialValue
     } catch (error) {
       // If error also return initialValue
-      console.error(error)
+      console.error(error) // eslint-disable-line no-console
       return initialValue
     }
   })
@@ -41,7 +41,7 @@ export function useLocalStorage<T>(
       window.localStorage.setItem(String(key), JSON.stringify(valueToStore))
     } catch (error) {
       // A more advanced implementation would handle the error case
-      console.error(error)
+      console.error(error) // eslint-disable-line no-console
     }
   }
   return [storedValue, setValue] as const


### PR DESCRIPTION
We were having an issue with the responses when the key has two words, like: currentPassword, to treat the error we need to convert the key current_password to currentPassword.

The other fix is to send query params to the redirectTo route on useUser. This happens when let's say I am in a page and for some reason got logged out, then I'll be redirected to auth/login and after login be able to be redirected back to the current page.