### PR TITLE
Ba fix remove module augmentation

### DIFF
--- a/.changeset/thick-roses-flash.md
+++ b/.changeset/thick-roses-flash.md
@@ -1,5 +1,0 @@
----
-"@baseapp-frontend/design-system-mui": patch
----
-
-Removing Module augmentation from MUI5

--- a/.changeset/thick-roses-flash.md
+++ b/.changeset/thick-roses-flash.md
@@ -1,0 +1,5 @@
+---
+"@baseapp-frontend/design-system-mui": patch
+---
+
+Removing Module augmentation from MUI5

--- a/packages/design-system-mui/CHANGELOG.md
+++ b/packages/design-system-mui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/design-system-mui
 
+## 1.3.2
+
+### Patch Changes
+
+- 7ce48f9: Removing Module augmentation from MUI5
+
 ## 1.3.1
 
 ### Minor Changes

--- a/packages/design-system-mui/package.json
+++ b/packages/design-system-mui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/design-system-mui",
   "description": "Design System components and configurations.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {

--- a/packages/design-system-mui/styles/theme.ts
+++ b/packages/design-system-mui/styles/theme.ts
@@ -1,17 +1,8 @@
 import { createTheme } from '@mui/material/styles'
 
 import { palette } from './palette'
-import { typography } from './typography'
 import { shadows } from './shadows'
-
-declare module '@mui/material/styles' {
-  interface Palette {
-    surface: typeof palette.surface
-  }
-  interface PaletteOptions {
-    surface: typeof palette.surface
-  }
-}
+import { typography } from './typography'
 
 const theme = createTheme({
   palette,


### PR DESCRIPTION
Removing Module augmentation that was causing issues with the local project, better will be to do that on you project like following example:

`
declare module '@mui/material/styles' {
  interface PaletteColor {
    A50: string
    A500: string
    A900: string
  }

  interface Palette {
    surface: Palette['primary']
  }

  interface PaletteOptions {
    surface: PaletteOptions['primary']
  }
}

declare module '@mui/material/Button' {
  interface ButtonPropsColorOverrides {
    surface: true;
  }
}`