### PR TITLE
(BA) reset user cache

### DIFF
--- a/packages/authentication/CHANGELOG.md
+++ b/packages/authentication/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/authentication
 
+## 1.0.2
+
+### Patch Changes
+
+- Reset user cache when `useUser` throws a 401 error.
+  - It was using `invalidateQueries` but this doesn't necessarily clean the user cache response, so changing to `resetQueries` is more effective.
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/authentication/modules/user/useUser/index.ts
+++ b/packages/authentication/modules/user/useUser/index.ts
@@ -23,11 +23,12 @@ const useUser = <TUser extends Partial<IUser>>({
     ...options, // needs to be placed bellow all overridable options
     onError: (error: any) => {
       if (error?.response?.status === 401) {
-        // since response is 401 Unauthorized it also prabably has the body:
+        // since response is 401 Unauthorized it also probably has the body:
         // {"detail":"Invalid token."}
-        // better remove the cookie
+        // is better to remove the cookie
         Cookies.remove(cookieName)
-        queryClient.invalidateQueries(USER_API_KEY.getUser())
+        // making sure to reset the cache
+        queryClient.resetQueries(USER_API_KEY.getUser())
       }
       options?.onError?.(error)
     },

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/authentication",
   "description": "Authentication modules.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {


### PR DESCRIPTION
* authentication package update - `v1.0.2`
  - Reset user cache when `useUser` throws a 401 error.
    - It was using `invalidateQueries` but this doesn't necessarily clean the user cache response, so changing to `resetQueries` is more effective.