### PR TITLE
HOTFIX: Cast camelize result instead of passing generic

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/utils
 
+## 1.2.2
+
+### Patch Changes
+
+- Cast types instead of using `camelizeKeys` generic.
+- Add missing export for `useDjangoOrderBy` hook.
+
 ## 1.2.1
 
 ### Patch Changes

--- a/packages/utils/functions/token/decodeJWT/index.ts
+++ b/packages/utils/functions/token/decodeJWT/index.ts
@@ -2,4 +2,4 @@ import humps from 'humps'
 import jwt_decode from 'jwt-decode'
 
 export const decodeJWT = <JWTContentType>(token: string) =>
-  humps.camelizeKeys<JWTContentType>(jwt_decode(token))
+  humps.camelizeKeys(jwt_decode(token)) as JWTContentType

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -12,8 +12,9 @@ export * from './functions/form'
 export * from './functions/string'
 export * from './functions/token'
 
-export { default as useDebounce } from './hooks/useDebounce'
 export * from './hooks/useEventSubscription'
+export { default as useDebounce } from './hooks/useDebounce'
+export { default as useDjangoOrderBy } from './hooks/useDjangoOrderBy'
 
 export type * from './types/cookie'
 export type * from './types/django'

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/utils",
   "description": "Util functions, constants and types.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {


### PR DESCRIPTION
camelizeKeys doesn't like the generic type apparently. Not sure if we need to update or what but casting seems to fix the issue.