### PR TITLE
Make ButtonWithLoading accept a ref

### DIFF
--- a/packages/design-system-mui/components/ButtonWithLoading/index.tsx
+++ b/packages/design-system-mui/components/ButtonWithLoading/index.tsx
@@ -1,20 +1,18 @@
-import { FC } from 'react'
+import { forwardRef } from 'react'
 
 import { Button } from '@mui/material'
 
 import { CircularProgress } from './styled'
 import { IButtonWitthLoadingProps } from './types'
 
-const ButtonWithLoading: FC<IButtonWitthLoadingProps> = ({
+export default forwardRef<HTMLButtonElement, IButtonWitthLoadingProps>(({
   children,
   isLoading = false,
   loadingComponent = <CircularProgress size="20px" />,
   ...props
-}) => (
-  <Button disabled={isLoading} {...props}>
+}, ref) => (
+  <Button disabled={isLoading} {...props} ref={ref}>
     {children}
     {isLoading && loadingComponent}
   </Button>
-)
-
-export default ButtonWithLoading
+))


### PR DESCRIPTION
Its needed so we can do stuff like:

```jsx
<Tooltip><ButtonWithLoading /></Tooltip>
```