### PR TITLE
GGL-159: update forgot password utils

### DIFF
--- a/packages/authentication/CHANGELOG.md
+++ b/packages/authentication/CHANGELOG.md
@@ -1,10 +1,21 @@
 # @baseapp-frontend/authentication
 
+## 1.1.4
+
+### Patch Changes
+
+- Update `useResetPassword` so it expects to receive a token as a hook parameter.
+- Set `onBlur` mode for most of the hookes that uses `useForm`.
+- Add a `{}` fallback for some hook'`s options.
+
+- Updated dependencies
+  - @baseapp-frontend/utils@1.3.0
+
 ## 1.1.3
 
 ### Patch Changes
 
-- update auth endpoint url path to match baseapp-django-v3. The default login path is `/auth/login` for both SimpleToken and JWT auth
+- Update auth endpoint url path to match baseapp-django-v3. The default login path is `/auth/login` for both Simple Token and JWT auth.
 
 ## 1.1.2
 

--- a/packages/authentication/modules/access/useLogin/index.ts
+++ b/packages/authentication/modules/access/useLogin/index.ts
@@ -61,7 +61,7 @@ const useLogin = ({
   cookieName = ACCESS_COOKIE_NAME,
   refreshCookieName = REFRESH_COOKIE_NAME,
   ApiClass = AuthApi,
-}: IUseLogin) => {
+}: IUseLogin = {}) => {
   const queryClient = useQueryClient()
   const [mfaEphemeralToken, setMfaEphemeralToken] = useState<string | null>(null)
   const { refetch: refetchUser } = useSimpleTokenUser({ options: { enabled: false } })
@@ -84,6 +84,7 @@ const useLogin = ({
   const form = useForm({
     defaultValues,
     resolver: yupResolver(validationSchema),
+    mode: 'onBlur',
   })
 
   const mutation = useMutation({
@@ -107,6 +108,7 @@ const useLogin = ({
     // TODO: refactor types
     defaultValues: CODE_VALIDATION_INITIAL_VALUES as FieldValues,
     resolver: yupResolver(CODE_VALIDATION_SCHEMA as any),
+    mode: 'onBlur',
   })
 
   const mfaMutation = useMutation((data: ILoginMfaRequest) => MfaApi.loginStep2(data), {

--- a/packages/authentication/modules/access/useRecoverPassword/index.ts
+++ b/packages/authentication/modules/access/useRecoverPassword/index.ts
@@ -14,10 +14,11 @@ const useRecoverPassword = ({
   defaultValues = DEFAULT_INITIAL_VALUES,
   ApiClass = AuthApi,
   options,
-}: IUseRecoverPassword) => {
+}: IUseRecoverPassword = {}) => {
   const form = useForm({
     defaultValues,
     resolver: yupResolver(validationSchema),
+    mode: 'onBlur',
   })
 
   const mutation = useMutation({

--- a/packages/authentication/modules/access/useResetPassword/__tests__/useResetPassword.test.tsx
+++ b/packages/authentication/modules/access/useResetPassword/__tests__/useResetPassword.test.tsx
@@ -21,9 +21,10 @@ describe('useResetPassword', () => {
     const { result } = renderHook(
       () =>
         useResetPassword({
+          token,
           defaultValues: {
             newPassword: password,
-            token,
+            confirmNewPassword: password,
           },
           options: {
             onSuccess: () => {
@@ -51,9 +52,10 @@ describe('useResetPassword', () => {
     const { result } = renderHook(
       () =>
         useResetPassword({
+          token,
           defaultValues: {
             newPassword: password,
-            token,
+            confirmNewPassword: password,
           },
           options: {
             onError: () => {

--- a/packages/authentication/modules/access/useResetPassword/constants.ts
+++ b/packages/authentication/modules/access/useResetPassword/constants.ts
@@ -4,10 +4,12 @@ import * as Yup from 'yup'
 
 export const DEFAULT_VALIDATION_SCHEMA = Yup.object().shape({
   newPassword: Yup.string().required(YUP_REQUIRED_FIELD),
-  token: Yup.string().required(YUP_REQUIRED_FIELD),
+  confirmNewPassword: Yup.string()
+    .required(YUP_REQUIRED_FIELD)
+    .oneOf([Yup.ref('newPassword')], 'Passwords must match.'),
 })
 
 export const DEFAULT_INITIAL_VALUES = {
   newPassword: '',
-  token: '',
+  confirmNewPassword: '',
 }

--- a/packages/authentication/modules/access/useResetPassword/index.ts
+++ b/packages/authentication/modules/access/useResetPassword/index.ts
@@ -5,11 +5,11 @@ import { useMutation } from '@tanstack/react-query'
 import { SubmitHandler, useForm } from 'react-hook-form'
 
 import AuthApi from '../../../services/auth'
-import { IResetPasswordRequest } from '../../../types/auth'
 import { DEFAULT_INITIAL_VALUES, DEFAULT_VALIDATION_SCHEMA } from './constants'
-import { IUseResetPassword } from './types'
+import { IUseResetPassword, ResetPasswordForm } from './types'
 
 const useResetPassword = ({
+  token,
   validationSchema = DEFAULT_VALIDATION_SCHEMA,
   defaultValues = DEFAULT_INITIAL_VALUES,
   ApiClass = AuthApi,
@@ -18,10 +18,11 @@ const useResetPassword = ({
   const form = useForm({
     defaultValues,
     resolver: yupResolver(validationSchema),
+    mode: 'onChange',
   })
 
   const mutation = useMutation({
-    mutationFn: ({ newPassword, token }) => ApiClass.resetPassword({ newPassword, token }),
+    mutationFn: ({ newPassword }) => ApiClass.resetPassword({ newPassword, token }),
     ...options, // needs to be placed bellow all overridable options
     onError: (err, variables, context) => {
       options?.onError?.(err, variables, context)
@@ -32,7 +33,7 @@ const useResetPassword = ({
     },
   })
 
-  const handleSubmit: SubmitHandler<IResetPasswordRequest> = async (values) => {
+  const handleSubmit: SubmitHandler<ResetPasswordForm> = async (values) => {
     try {
       await mutation.mutateAsync(values)
     } catch (error) {

--- a/packages/authentication/modules/access/useResetPassword/types.ts
+++ b/packages/authentication/modules/access/useResetPassword/types.ts
@@ -1,14 +1,19 @@
 import { UseMutationOptions } from '@tanstack/react-query'
 
 import AuthApi from '../../../services/auth'
-import { IResetPasswordRequest } from '../../../types/auth'
 
 type ApiClass = Pick<typeof AuthApi, 'resetPassword'>
 
+export type ResetPasswordForm = {
+  newPassword: string
+  confirmNewPassword: string
+}
+
 export interface IUseResetPassword {
+  token: string
   // TODO: refactor types
   validationSchema?: any
-  defaultValues?: IResetPasswordRequest
-  options?: UseMutationOptions<void, unknown, IResetPasswordRequest, any>
+  defaultValues?: ResetPasswordForm
+  options?: UseMutationOptions<void, unknown, ResetPasswordForm, any>
   ApiClass?: ApiClass
 }

--- a/packages/authentication/modules/access/useSignUp/index.ts
+++ b/packages/authentication/modules/access/useSignUp/index.ts
@@ -14,7 +14,7 @@ const useSignUp = <TRegisterRequest extends IRegisterRequest, TRegisterResponse 
   defaultValues = DEFAULT_INITIAL_VALUES as TRegisterRequest,
   ApiClass = AuthApi,
   options,
-}: IUseSignUp<TRegisterRequest, TRegisterResponse>) => {
+}: IUseSignUp<TRegisterRequest, TRegisterResponse> = {}) => {
   const form = useForm({
     // @ts-ignore TODO: DeepPartial type error will be fixed on v8
     defaultValues,

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/authentication",
   "description": "Authentication modules.",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/utils
 
+## 1.3.0
+
+### Minor Changes
+
+- Update `withController` so it passes a `helperText` and an `error` prop to the component. So it fits better the MUI's error display dynamic.
+
 ## 1.2.2
 
 ### Patch Changes

--- a/packages/utils/functions/form/withController/__tests__/withController.test.tsx
+++ b/packages/utils/functions/form/withController/__tests__/withController.test.tsx
@@ -23,7 +23,7 @@ describe('withController', () => {
 
   it('should pass down the correct props', () => {
     const { queryByText } = render(
-      <WrappedComponent name="test" someProp="prop" control={{}} enableError />,
+      <WrappedComponent name="test" someProp="prop" control={{}} error />,
     )
     const testComponent = queryByText('Test')
 

--- a/packages/utils/functions/form/withController/index.tsx
+++ b/packages/utils/functions/form/withController/index.tsx
@@ -5,14 +5,20 @@ import { Controller } from 'react-hook-form'
 import { WithControllerProps } from './types'
 
 function withController<T>(Component: FC<T>) {
-  return ({ name, control, ...props }: WithControllerProps<T>) => {
+  return ({ name, control, helperText, ...props }: WithControllerProps<T>) => {
     if (control) {
       return (
         <Controller
           name={name}
           control={control}
           render={({ field, fieldState }) => (
-            <Component {...field} error={fieldState.error} name={name} {...(props as any)} />
+            <Component
+              {...field}
+              error={!!fieldState.error}
+              name={name}
+              helperText={helperText || (!!fieldState.error && fieldState.error?.message)}
+              {...(props as any)}
+            />
           )}
         />
       )

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/utils",
   "description": "Util functions, constants and types.",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {

--- a/packages/utils/types/form.ts
+++ b/packages/utils/types/form.ts
@@ -1,12 +1,6 @@
-import { Control, ControllerProps, FieldError, FieldValues } from 'react-hook-form'
+import { Control, ControllerProps, FieldValues } from 'react-hook-form'
 
 import { RequireAllOrNone } from './typescript'
-
-export interface IFormControl extends Pick<ControllerProps, 'name'> {
-  control?: Control<FieldValues[string]>
-  error?: FieldError
-  enableError?: boolean
-}
 
 export type ControlProps = RequireAllOrNone<{
   control?: Control<FieldValues[string]>
@@ -14,6 +8,5 @@ export type ControlProps = RequireAllOrNone<{
 }>
 
 export type FormControl = ControlProps & {
-  error?: FieldError
-  enableError?: boolean
+  helperText?: any
 }


### PR DESCRIPTION
* authentication package update - `v1.1.4`
  - Update `useResetPassword` so it expects to receive a token as a hook parameter.
  - Set `onBlur` mode for most of the hookes that uses `useForm`.
  - Add a `{}` fallback for some hook'`s options.

* utils package update - `v1.3.0`
  - Update `withController` so it passes a `helperText` and an `error` prop to the component. So it fits better the MUI's error display dynamic.