### PR TITLE
BA: pass helperText prop without having set a control on withController

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/utils
 
+## 1.3.2
+
+### Patch Changes
+
+- Update `withController` so it passes a `helperText` props even if there is no `control` props used.
+
 ## 1.3.1
 
 ### Patch Changes

--- a/packages/utils/functions/form/withController/__tests__/withController.test.tsx
+++ b/packages/utils/functions/form/withController/__tests__/withController.test.tsx
@@ -17,17 +17,21 @@ describe('withController', () => {
   })
 
   it('should directly render the passed component if control prop is not provided', () => {
-    const { queryByText } = render(<WrappedComponent name="test" />)
-    expect(queryByText('Test')).toBeInTheDocument()
+    const { queryByText } = render(<WrappedComponent name="test" helperText="some helper" />)
+    const testComponent = queryByText('Test')
+
+    expect(testComponent).toHaveAttribute('name', 'test')
+    expect(testComponent).toHaveAttribute('helperText', 'some helper')
   })
 
   it('should pass down the correct props', () => {
     const { queryByText } = render(
-      <WrappedComponent name="test" someProp="prop" control={{}} error />,
+      <WrappedComponent name="test" someProp="prop" control={{}} helperText="some helper" />,
     )
     const testComponent = queryByText('Test')
 
     expect(testComponent).toHaveAttribute('name', 'test')
     expect(testComponent).toHaveAttribute('someProp', 'prop')
+    expect(testComponent).toHaveAttribute('helperText', 'some helper')
   })
 })

--- a/packages/utils/functions/form/withController/index.tsx
+++ b/packages/utils/functions/form/withController/index.tsx
@@ -24,7 +24,7 @@ function withController<T>(Component: FC<T>) {
       )
     }
 
-    return <Component name={name} {...(props as T)} />
+    return <Component name={name} helperText={helperText} {...(props as T)} />
   }
 }
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/utils",
   "description": "Util functions, constants and types.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {


### PR DESCRIPTION
* utils package update - `v1.3.2`
  - Update `withController` so it passes a `helperText` props even if there is no `control` props used.