### PR TITLE
BA: remove resolved promise on 401 responses

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/utils
 
+## 1.3.3
+
+### Patch Changes
+
+- Remove `Promise.resolve()` when the request throws a `401` after the refresh token attempt.
+
 ## 1.3.2
 
 ### Patch Changes

--- a/packages/utils/functions/axios/createAxiosInstance/index.ts
+++ b/packages/utils/functions/axios/createAxiosInstance/index.ts
@@ -79,7 +79,6 @@ export const createAxiosInstance = ({
         } catch (refreshError) {
           if (eventEmitter.listenerCount(LOGOUT_EVENT)) {
             eventEmitter.emit(LOGOUT_EVENT)
-            return Promise.resolve()
           }
         }
       }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/utils",
   "description": "Util functions, constants and types.",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {


### PR DESCRIPTION
* utils package update - `v1.3.3`
  - Remove `Promise.resolve()` when the request throws a `401` after the refresh token attempt.