### PR TITLE
BA: services without token regex

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/utils
 
+## 1.3.4
+
+### Patch Changes
+
+- `servicesWithoutToken` should now be a list of Regex Expressions to match the request url more precisely.
+
 ## 1.3.3
 
 ### Patch Changes

--- a/packages/utils/constants/axios.ts
+++ b/packages/utils/constants/axios.ts
@@ -1,7 +1,8 @@
 export const SERVICES_WITHOUT_TOKEN = [
-  '/auth',
-  '/auth/login',
-  '/register',
-  '/forgot-password',
-  '/forgot-password/reset',
+  /\/auth$/,
+  /\/auth\/login$/,
+  /\/register$/,
+  /\/forgot-password$/,
+  /\/forgot-password\/reset$/,
+  /\/users\/\d+\/pre-auth$/,
 ]

--- a/packages/utils/functions/axios/createAxiosInstance/__tests__/createAxiosInstance.test.ts
+++ b/packages/utils/functions/axios/createAxiosInstance/__tests__/createAxiosInstance.test.ts
@@ -78,12 +78,19 @@ describe('createAxiosInstance', () => {
           request: { use },
         },
       },
-    } = createAxiosInstance({ servicesWithoutToken: ['/someUrl'] })
+    } = createAxiosInstance({
+      servicesWithoutToken: [/\/someUrl$/, /\/someUrl\/\d+\/withSomethingInTheMiddle$/],
+    })
     const [[interceptorFn]] = (use as jest.Mock).mock.calls
-    const request = { headers: { Authorization: undefined }, url: '/someUrl' }
-
+    let request = { headers: { Authorization: undefined }, url: '/someUrl' }
     interceptorFn(request)
+    expect(request.headers.Authorization).toBeUndefined()
 
+    request = {
+      headers: { Authorization: undefined },
+      url: '/someUrl/123/withSomethingInTheMiddle',
+    }
+    interceptorFn(request)
     expect(request.headers.Authorization).toBeUndefined()
   })
 

--- a/packages/utils/functions/axios/createAxiosInstance/index.ts
+++ b/packages/utils/functions/axios/createAxiosInstance/index.ts
@@ -41,7 +41,7 @@ export const createAxiosInstance = ({
       if (
         request.headers &&
         !request.headers.Authorization &&
-        !servicesWithoutToken.includes(request.url || '')
+        !servicesWithoutToken.some((regex) => regex.test(request.url || ''))
       ) {
         request.headers.Authorization =
           tokenType === TokenTypes.jwt ? `Bearer ${authToken}` : `Token ${authToken}`

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/utils",
   "description": "Util functions, constants and types.",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {


### PR DESCRIPTION
* `utils` package update - `v1.3.4`
  - `servicesWithoutToken` should now be a list of Regex Expressions to match the request url more precisely.
