### PR TITLE
BA-1232: pre-authenticated link & shorten links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,11 @@ yarn-error.log*
 
 # typescript
 tsconfig.tsbuildinfo
+
+# workspace files are user-specific
+*.sublime-workspace
+**/sitemap*.xml
+**/*.code-workspace
+**/.vscode
+**/routes.json
+.idea/

--- a/packages/authentication/CHANGELOG.md
+++ b/packages/authentication/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/authentication
 
+## 1.2.2
+
+### Patch Changes
+
+- Pre Authenticated URL handling
+- Short URL handling
+
 ## 1.2.1
 
 ### Patch Changes

--- a/packages/authentication/modules/access/index.ts
+++ b/packages/authentication/modules/access/index.ts
@@ -1,5 +1,5 @@
 export { default as useLogin } from './useLogin'
-export * from './useLogin/utils'
+export * from '../../utils/login'
 export type * from './useLogin/types'
 
 export { default as useLogout } from './useLogout'
@@ -13,3 +13,6 @@ export type * from './useResetPassword/types'
 
 export { default as useSignUp } from './useSignUp'
 export type * from './useSignUp/types'
+
+export { default as usePreAuth } from './usePreAuth'
+export type * from './usePreAuth/types'

--- a/packages/authentication/modules/access/useLogin/index.ts
+++ b/packages/authentication/modules/access/useLogin/index.ts
@@ -21,11 +21,11 @@ import {
   ILoginRequest,
   ILoginSimpleTokenResponse,
 } from '../../../types/auth'
+import { isJWTResponse, isLoginMfaResponse } from '../../../utils/login'
 import { CODE_VALIDATION_INITIAL_VALUES, CODE_VALIDATION_SCHEMA } from '../../mfa/constants'
 import { useSimpleTokenUser } from '../../user'
 import { DEFAULT_INITIAL_VALUES, DEFAULT_VALIDATION_SCHEMA } from './constants'
 import { IUseLogin } from './types'
-import { isJWTResponse, isLoginMfaResponse } from './utils'
 
 const jwtSuccessHandler = (
   response: ILoginJWTResponse,

--- a/packages/authentication/modules/access/usePreAuth/__tests__/usePreAuth.test.tsx
+++ b/packages/authentication/modules/access/usePreAuth/__tests__/usePreAuth.test.tsx
@@ -1,0 +1,51 @@
+import { ComponentWithProviders, MockAdapter, renderHook, waitFor } from '@baseapp-frontend/test'
+import { axios } from '@baseapp-frontend/utils'
+import { TokenTypes } from '@baseapp-frontend/utils/constants/token'
+
+import usePreAuth from '../index'
+
+// @ts-ignore TODO: (BA-1081) investigate AxiosRequestHeaders error
+export const axiosMock = new MockAdapter(axios)
+
+describe('usePreAuth jwt', () => {
+  test('should run onSuccess', async () => {
+    axiosMock.onPost('/auth/pre-auth/jwt').reply(200, {
+      refresh: 'fake-refresh-token',
+      access: 'fake-access-token',
+    })
+
+    const { result } = renderHook(
+      () =>
+        usePreAuth({
+          token: 'fake-pre-auth-token',
+          tokenType: TokenTypes.jwt,
+        }),
+      {
+        wrapper: ComponentWithProviders,
+      },
+    )
+
+    await waitFor(() => expect(result.current.query.isSuccess).toBe(true))
+  })
+})
+
+describe('usePreAuth auth_token', () => {
+  test('should run onSuccess', async () => {
+    axiosMock.onPost('/auth/pre-auth/auth-token').reply(200, {
+      token: 'fake-auth-token',
+    })
+
+    const { result } = renderHook(
+      () =>
+        usePreAuth({
+          token: 'fake-pre-auth-token',
+          tokenType: TokenTypes.simple,
+        }),
+      {
+        wrapper: ComponentWithProviders,
+      },
+    )
+
+    await waitFor(() => expect(result.current.query.isSuccess).toBe(true))
+  })
+})

--- a/packages/authentication/modules/access/usePreAuth/index.ts
+++ b/packages/authentication/modules/access/usePreAuth/index.ts
@@ -1,0 +1,58 @@
+import { ACCESS_COOKIE_NAME, REFRESH_COOKIE_NAME, TokenTypes } from '@baseapp-frontend/utils'
+
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import Cookies from 'js-cookie'
+
+import AuthApi, { PRE_AUTH_API_KEY } from '../../../services/auth'
+import { USER_API_KEY } from '../../../services/user'
+import { isJWTResponse } from '../../../utils/login'
+import { useSimpleTokenUser } from '../../user'
+import { IUsePreAuth } from './types'
+
+const usePreAuth = ({
+  token,
+  queryOptions = {},
+  tokenType = TokenTypes.jwt,
+  cookieName = ACCESS_COOKIE_NAME,
+  refreshCookieName = REFRESH_COOKIE_NAME,
+  ApiClass = AuthApi,
+}: IUsePreAuth) => {
+  const queryClient = useQueryClient()
+  const { refetch: refetchUser } = useSimpleTokenUser({ options: { enabled: false } })
+
+  const query = useQuery({
+    enabled: !!token,
+    useErrorBoundary: false,
+    retry: false,
+    ...queryOptions, // needs to be placed bellow all overridable options
+    queryKey: PRE_AUTH_API_KEY.preAuth(token, tokenType),
+    queryFn: () => ApiClass.preAuth({ token }, tokenType),
+    onSuccess: (response) => {
+      if (isJWTResponse(tokenType, response)) {
+        Cookies.set(cookieName, response.access, {
+          secure: process.env.NODE_ENV === 'production',
+        })
+        Cookies.set(refreshCookieName, response.refresh, {
+          secure: process.env.NODE_ENV === 'production',
+        })
+      } else {
+        Cookies.set(cookieName, response.token, {
+          secure: process.env.NODE_ENV === 'production',
+        })
+      }
+      queryClient.resetQueries(USER_API_KEY.getUser())
+      refetchUser()
+
+      queryOptions?.onSuccess?.(response)
+    },
+    onError: (error: any) => {
+      queryOptions?.onError?.(error)
+    },
+  })
+
+  return {
+    query,
+  }
+}
+
+export default usePreAuth

--- a/packages/authentication/modules/access/usePreAuth/types.ts
+++ b/packages/authentication/modules/access/usePreAuth/types.ts
@@ -1,0 +1,15 @@
+import { TokenTypes } from '@baseapp-frontend/utils'
+
+import { UseQueryOptions } from '@tanstack/react-query'
+
+import AuthApi from '../../../services/auth'
+import { ICookieName, IPreAuthRequest, PreAuthResponse } from '../../../types/auth'
+
+type ApiClass = Pick<typeof AuthApi, 'preAuth'>
+
+export interface IUsePreAuth extends ICookieName {
+  token: string
+  queryOptions?: UseQueryOptions<PreAuthResponse, unknown, IPreAuthRequest, any>
+  tokenType?: TokenTypes
+  ApiClass?: ApiClass
+}

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/authentication",
   "description": "Authentication modules.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {

--- a/packages/authentication/services/auth.ts
+++ b/packages/authentication/services/auth.ts
@@ -1,11 +1,14 @@
 import { axios } from '@baseapp-frontend/utils'
+import { TokenTypes } from '@baseapp-frontend/utils/constants/token'
 
 import {
   IForgotPasswordRequest,
   ILoginRequest,
+  IPreAuthRequest,
   IRegisterRequest,
   IResetPasswordRequest,
   LoginResponse,
+  PreAuthResponse,
 } from '../types/auth'
 
 export default class AuthApi {
@@ -24,4 +27,21 @@ export default class AuthApi {
   static register<TResponse = void>(request: IRegisterRequest): Promise<TResponse> {
     return axios.post(`/register`, request)
   }
+
+  static preAuth(request: IPreAuthRequest, tokenType: TokenTypes): Promise<PreAuthResponse> {
+    switch (tokenType) {
+      case TokenTypes.jwt:
+        return axios.post(`/auth/pre-auth/jwt`, request)
+      case TokenTypes.simple:
+        return axios.post(`/auth/pre-auth/auth-token`, request)
+      default:
+        return Promise.reject(new Error(`Unknown token type: ${tokenType}`))
+    }
+  }
+}
+
+export const PRE_AUTH_API_KEY = {
+  default: ['auth'],
+  preAuth: (token: string, tokenType: TokenTypes) =>
+    [...PRE_AUTH_API_KEY.default, 'preAuth', token, tokenType] as const,
 }

--- a/packages/authentication/types/auth.ts
+++ b/packages/authentication/types/auth.ts
@@ -46,3 +46,9 @@ export interface ICookieName {
   cookieName?: string
   refreshCookieName?: string
 }
+
+export interface IPreAuthRequest {
+  token: string
+}
+
+export type PreAuthResponse = ILoginSimpleTokenResponse | ILoginJWTResponse

--- a/packages/authentication/utils/login.ts
+++ b/packages/authentication/utils/login.ts
@@ -5,7 +5,7 @@ import {
   ILoginMfaResponse,
   ILoginSimpleTokenResponse,
   LoginResponse,
-} from '../../../types/auth'
+} from '../types/auth'
 
 export const isLoginMfaResponse = (data: LoginResponse): data is ILoginMfaResponse => {
   const mfaKey: keyof ILoginMfaResponse = 'method'


### PR DESCRIPTION
Acceptance Criteria:

It should be able to generate pre-authenticated links for a user
** different pre authenticated links should be able to work, even if it's generated for the same user
** pre-auth links should work with JWT auth
** the token will still be valid as long as the underlying access token lives (base it on a separate Access Token that is set to ** expire in longer time than the normal access token, e.g. 1 week)
** if using Simple Auth (not JWT), support the expiration of pre-auth links too

Add the ability to generate shortened URLs links
** shorten by default

Inspiration (single use token):
** [https://bitbucket.org/silverlogic/ggl-web/src/ggl-post-mvp-epic/app/c/[shortCode]/](https://bitbucket.org/silverlogic/ggl-web/src/ggl-post-mvp-epic/app/c/%5BshortCode%5D/)
** [https://bitbucket.org/silverlogic/ggl-web/src/ggl-post-mvp-epic/app/pre-auth/[userId]/page.tsx](https://bitbucket.org/silverlogic/ggl-web/src/ggl-post-mvp-epic/app/pre-auth/%5BuserId%5D/page.tsx)
** https://bitbucket.org/silverlogic/ggl-api/pull-requests/2

add tests for both FE and BE implementations

Demo Link: TODO