### PR TITLE
GGL-288: update withController actions

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/utils
 
+## 1.3.6
+
+### Patch Changes
+
+- Allow custom `onChange` and `onBlur` functions to be passed along with a controlled component, without overriding the built-in Controller's functions.
+
 ## 1.3.5
 
 ### Patch Changes

--- a/packages/utils/functions/form/withController/__tests__/withController.test.tsx
+++ b/packages/utils/functions/form/withController/__tests__/withController.test.tsx
@@ -1,37 +1,76 @@
-import { render } from '@baseapp-frontend/test'
+import { render, userEvent } from '@baseapp-frontend/test'
 
 import withController from '..'
 
+const mockFieldOnChange = jest.fn()
+const mockFieldOnBlur = jest.fn()
+
 jest.mock('react-hook-form', () => ({
   ...jest.requireActual('react-hook-form'),
-  Controller: ({ render: r }: { render: any }) => r({ field: {}, fieldState: {} }),
+  Controller: ({ render: r }: { render: any }) =>
+    r({
+      field: {
+        onChange: mockFieldOnChange,
+        onBlur: mockFieldOnBlur,
+      },
+      fieldState: {},
+    }),
 }))
 
 describe('withController', () => {
-  const TestComponent = (props: any) => <div {...props}>Test</div>
+  const TestComponent = (props: any) => <input data-testid="test-input" {...props} />
   const WrappedComponent = withController(TestComponent)
 
   it('should render the Controller component if control prop is provided', () => {
-    const { queryByText } = render(<WrappedComponent name="test" control={{}} />)
-    expect(queryByText('Test')).toBeInTheDocument()
+    const { queryByTestId } = render(<WrappedComponent name="test" control={{}} />)
+    expect(queryByTestId('test-input')).toBeInTheDocument()
   })
 
   it('should directly render the passed component if control prop is not provided', () => {
-    const { queryByText } = render(<WrappedComponent name="test" helperText="some helper" />)
-    const testComponent = queryByText('Test')
+    const { queryByTestId } = render(<WrappedComponent name="test" helperText="some helper" />)
+    const testComponent = queryByTestId('test-input')
 
     expect(testComponent).toHaveAttribute('name', 'test')
     expect(testComponent).toHaveAttribute('helperText', 'some helper')
   })
 
   it('should pass down the correct props', () => {
-    const { queryByText } = render(
+    const { queryByTestId } = render(
       <WrappedComponent name="test" someProp="prop" control={{}} helperText="some helper" />,
     )
-    const testComponent = queryByText('Test')
+    const testComponent = queryByTestId('test-input')
 
     expect(testComponent).toHaveAttribute('name', 'test')
     expect(testComponent).toHaveAttribute('someProp', 'prop')
     expect(testComponent).toHaveAttribute('helperText', 'some helper')
+  })
+
+  it("should trigger the passed onChange function and the built-in Controller's onChange when the component's onChange is called", async () => {
+    const user = userEvent.setup()
+    const mockOnChange = jest.fn()
+    const { findByTestId } = render(
+      <WrappedComponent name="test" control={{}} onChange={mockOnChange} />,
+    )
+
+    const testComponent = await findByTestId('test-input')
+    await user.type(testComponent, 'test')
+
+    expect(mockOnChange).toHaveBeenCalledTimes(4)
+    expect(mockFieldOnChange).toHaveBeenCalledTimes(4)
+  })
+
+  it("should trigger the passed onBlur function and the built-in Controller's onBlur when the component's onBlur is called", async () => {
+    const user = userEvent.setup()
+    const mockOnBlur = jest.fn()
+    const { findByTestId } = render(
+      <WrappedComponent name="test" control={{}} onBlur={mockOnBlur} />,
+    )
+
+    const testComponent = await findByTestId('test-input')
+    await user.type(testComponent, 'test')
+    await user.tab()
+
+    expect(mockOnBlur).toHaveBeenCalledTimes(1)
+    expect(mockFieldOnBlur).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/utils/functions/form/withController/index.tsx
+++ b/packages/utils/functions/form/withController/index.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { ChangeEvent, FC } from 'react'
 
 import { Controller } from 'react-hook-form'
 
@@ -7,19 +7,33 @@ import { WithControllerProps } from './types'
 function withController<T>(Component: FC<T>) {
   return ({ name, control, helperText, ...props }: WithControllerProps<T>) => {
     if (control) {
+      const { onChange, onBlur, ...restOfTheProps } = props
       return (
         <Controller
           name={name}
           control={control}
-          render={({ field, fieldState }) => (
-            <Component
-              {...field}
-              error={!!fieldState.error}
-              name={name}
-              helperText={helperText || (!!fieldState.error && fieldState.error?.message)}
-              {...(props as any)}
-            />
-          )}
+          render={({ field, fieldState }) => {
+            const handleOnChange = (event: ChangeEvent) => {
+              field.onChange(event)
+              onChange?.(event)
+            }
+            const handleOnBlur = () => {
+              field.onBlur()
+              onBlur?.()
+            }
+
+            return (
+              <Component
+                {...field}
+                error={!!fieldState.error}
+                name={name}
+                onChange={handleOnChange}
+                onBlur={handleOnBlur}
+                helperText={helperText || (!!fieldState.error && fieldState.error?.message)}
+                {...(restOfTheProps as any)}
+              />
+            )
+          }}
         />
       )
     }

--- a/packages/utils/functions/form/withController/types.ts
+++ b/packages/utils/functions/form/withController/types.ts
@@ -1,3 +1,8 @@
 import { FormControl } from '../../../types/form'
 
-export type WithControllerProps<T> = FormControl & T
+type OptionalActions = {
+  onChange?: (value: any) => void
+  onBlur?: () => void
+}
+
+export type WithControllerProps<T> = FormControl & T & OptionalActions

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/utils",
   "description": "Util functions, constants and types.",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {


### PR DESCRIPTION
* `utils` package update - `v1.3.6`
  - Allow custom `onChange` and `onBlur` functions to be passed along with a controlled component, without overriding the built-in Controller's functions.
