### PR TITLE
AIRTAB-1013: graphql package creation and other package improvements

### DIFF
--- a/packages/authentication/CHANGELOG.md
+++ b/packages/authentication/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @baseapp-frontend/authentication
 
+## 1.2.3
+
+### Patch Changes
+
+- Add `enableFormApiErrors` option to all the hooks that were using `setFormApiErrors`. It now conditionally sets form errors based on the API response.
+- Add the `mode` option to the `useSignUp` hook.
+- Updated dependencies
+  - @baseapp-frontend/utils@1.3.7
+
 ## 1.2.2
 
 ### Patch Changes

--- a/packages/authentication/modules/access/useLogin/index.ts
+++ b/packages/authentication/modules/access/useLogin/index.ts
@@ -61,13 +61,14 @@ const useLogin = ({
   cookieName = ACCESS_COOKIE_NAME,
   refreshCookieName = REFRESH_COOKIE_NAME,
   ApiClass = AuthApi,
+  enableFormApiErrors = true,
 }: IUseLogin = {}) => {
   const queryClient = useQueryClient()
   const [mfaEphemeralToken, setMfaEphemeralToken] = useState<string | null>(null)
   const { refetch: refetchUser } = useSimpleTokenUser({ options: { enabled: false } })
 
   /*
-   * Handles login success with the auth token in response
+   * Handles login success  with the auth token in response
    */
   async function handleLoginSuccess(response: ILoginJWTResponse | ILoginSimpleTokenResponse) {
     if (isJWTResponse(tokenType, response)) {
@@ -92,7 +93,9 @@ const useLogin = ({
     ...loginOptions, // needs to be placed bellow all overridable options
     onError: (err, variables, context) => {
       loginOptions?.onError?.(err, variables, context)
-      setFormApiErrors(form, err)
+      if (enableFormApiErrors) {
+        setFormApiErrors(form, err)
+      }
     },
     onSuccess: async (response, variables, context) => {
       if (isLoginMfaResponse(response)) {
@@ -114,7 +117,9 @@ const useLogin = ({
     ...mfaOptions, // needs to be placed bellow all overridable options
     onError: (err, variables, context) => {
       mfaOptions?.onError?.(err, variables, context)
-      setFormApiErrors(form, err) // this is important to show backend errors on each specific field
+      if (enableFormApiErrors) {
+        setFormApiErrors(form, err)
+      }
     },
     onSuccess: (response, variables, context) => {
       handleLoginSuccess(response)

--- a/packages/authentication/modules/access/useLogin/types.ts
+++ b/packages/authentication/modules/access/useLogin/types.ts
@@ -15,4 +15,5 @@ export interface IUseLogin extends ICookieName {
   mfaOptions?: UseMutationOptions<LoginResponse, unknown, ILoginMfaRequest, any>
   tokenType?: TokenTypes
   ApiClass?: ApiClass
+  enableFormApiErrors?: boolean
 }

--- a/packages/authentication/modules/access/useRecoverPassword/index.ts
+++ b/packages/authentication/modules/access/useRecoverPassword/index.ts
@@ -13,7 +13,8 @@ const useRecoverPassword = ({
   validationSchema = DEFAULT_VALIDATION_SCHEMA,
   defaultValues = DEFAULT_INITIAL_VALUES,
   ApiClass = AuthApi,
-  options,
+  enableFormApiErrors = true,
+  options = {},
 }: IUseRecoverPassword = {}) => {
   const form = useForm({
     defaultValues,
@@ -26,7 +27,9 @@ const useRecoverPassword = ({
     ...options, // needs to be placed bellow all overridable options
     onError: (err, variables, context) => {
       options?.onError?.(err, variables, context)
-      setFormApiErrors(form, err) // this is important to show backend errors on each specific field
+      if (enableFormApiErrors) {
+        setFormApiErrors(form, err)
+      }
     },
     onSuccess: (response, variables, context) => {
       options?.onSuccess?.(response, variables, context)

--- a/packages/authentication/modules/access/useRecoverPassword/types.ts
+++ b/packages/authentication/modules/access/useRecoverPassword/types.ts
@@ -11,4 +11,5 @@ export interface IUseRecoverPassword {
   defaultValues?: IForgotPasswordRequest
   options?: UseMutationOptions<void, unknown, IForgotPasswordRequest, any>
   ApiClass?: ApiClass
+  enableFormApiErrors?: boolean
 }

--- a/packages/authentication/modules/access/useResetPassword/index.ts
+++ b/packages/authentication/modules/access/useResetPassword/index.ts
@@ -13,7 +13,8 @@ const useResetPassword = ({
   validationSchema = DEFAULT_VALIDATION_SCHEMA,
   defaultValues = DEFAULT_INITIAL_VALUES,
   ApiClass = AuthApi,
-  options,
+  enableFormApiErrors = true,
+  options = {},
 }: IUseResetPassword) => {
   const form = useForm({
     defaultValues,
@@ -26,7 +27,9 @@ const useResetPassword = ({
     ...options, // needs to be placed bellow all overridable options
     onError: (err, variables, context) => {
       options?.onError?.(err, variables, context)
-      setFormApiErrors(form, err) // this is important to show backend errors on each specific field
+      if (enableFormApiErrors) {
+        setFormApiErrors(form, err)
+      }
     },
     onSuccess: (response, variables, context) => {
       options?.onSuccess?.(response, variables, context)

--- a/packages/authentication/modules/access/useResetPassword/types.ts
+++ b/packages/authentication/modules/access/useResetPassword/types.ts
@@ -16,4 +16,5 @@ export interface IUseResetPassword {
   defaultValues?: ResetPasswordForm
   options?: UseMutationOptions<void, unknown, ResetPasswordForm, any>
   ApiClass?: ApiClass
+  enableFormApiErrors?: boolean
 }

--- a/packages/authentication/modules/access/useSignUp/index.ts
+++ b/packages/authentication/modules/access/useSignUp/index.ts
@@ -13,12 +13,14 @@ const useSignUp = <TRegisterRequest extends IRegisterRequest, TRegisterResponse 
   validationSchema = DEFAULT_VALIDATION_SCHEMA,
   defaultValues = DEFAULT_INITIAL_VALUES as TRegisterRequest,
   ApiClass = AuthApi,
-  options,
+  enableFormApiErrors = true,
+  options = {},
 }: IUseSignUp<TRegisterRequest, TRegisterResponse> = {}) => {
   const form = useForm({
     // @ts-ignore TODO: DeepPartial type error will be fixed on v8
     defaultValues,
     resolver: zodResolver(validationSchema),
+    mode: 'onBlur',
   })
 
   const mutation = useMutation({
@@ -26,7 +28,9 @@ const useSignUp = <TRegisterRequest extends IRegisterRequest, TRegisterResponse 
     ...options, // needs to be placed bellow all overridable options
     onError: (err, variables, context) => {
       options?.onError?.(err, variables, context)
-      setFormApiErrors(form, err) // this is important to show backend errors on each specific field
+      if (enableFormApiErrors) {
+        setFormApiErrors(form, err)
+      }
     },
     onSuccess: (response, variables, context) => {
       options?.onSuccess?.(response, variables, context)

--- a/packages/authentication/modules/access/useSignUp/types.ts
+++ b/packages/authentication/modules/access/useSignUp/types.ts
@@ -11,4 +11,5 @@ export interface IUseSignUp<TRegisterRequest = IRegisterRequest, TRegisterRespon
   defaultValues?: TRegisterRequest
   ApiClass?: ApiClass
   options?: UseMutationOptions<TRegisterResponse, unknown, TRegisterRequest, any>
+  enableFormApiErrors?: boolean
 }

--- a/packages/authentication/modules/mfa/useMfaActivateConfirm/index.ts
+++ b/packages/authentication/modules/mfa/useMfaActivateConfirm/index.ts
@@ -13,6 +13,7 @@ const useMfaActivateConfirm = ({
   validationSchema = CODE_VALIDATION_SCHEMA,
   defaultValues = CODE_VALIDATION_INITIAL_VALUES,
   ApiClass = MfaApi,
+  enableFormApiErrors = true,
   options = {},
 }: IUseMfaActivateConfirm) => {
   const form = useForm({
@@ -26,7 +27,9 @@ const useMfaActivateConfirm = ({
     ...options, // needs to be placed bellow all overridable options
     onError: (err, variables, context) => {
       options?.onError?.(err, variables, context)
-      setFormApiErrors(form, err) // this is important to show backend errors on each specific field
+      if (enableFormApiErrors) {
+        setFormApiErrors(form, err)
+      }
     },
     onSuccess: (response, variables, context) => {
       options?.onSuccess?.(response, variables, context)

--- a/packages/authentication/modules/mfa/useMfaActivateConfirm/types.ts
+++ b/packages/authentication/modules/mfa/useMfaActivateConfirm/types.ts
@@ -12,4 +12,5 @@ export interface IUseMfaActivateConfirm {
   options?: UseMutationOptions<IMfaConfirmationResponse, unknown, IMfaRequest, any>
   ApiClass?: ApiClass
   method: MfaMethod
+  enableFormApiErrors?: boolean
 }

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/authentication",
   "description": "Authentication modules.",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {

--- a/packages/config/.eslintrc.js
+++ b/packages/config/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     'next.config.js',
     'postcss.config.js',
     'tailwind.config.js',
+    'relay.config.js',
   ],
   extends: [
     'next',

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/config
 
+## 2.1.1
+
+### Patch Changes
+
+- Include `relay.config.js` in the `ignorePatterns` list.
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/config",
   "description": "Reusable configurations for eslint, prettier and jest.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "index.js",
   "files": [
     ".eslintrc.js",

--- a/packages/graphql/.eslintrc.js
+++ b/packages/graphql/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@baseapp-frontend/config/.eslintrc.js')

--- a/packages/graphql/.prettierrc.js
+++ b/packages/graphql/.prettierrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@baseapp-frontend/config/.prettierrc.js')

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @baseapp-frontend/graphql
+
+## 1.0.0
+
+### Major Changes
+
+- Creates the `graphql` package.
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/utils@1.3.7

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -1,0 +1,159 @@
+# **`@baseapp-frontend/graphql`**
+
+## **Overview**
+
+This package includes GraphQL's configurations and utilities.
+
+## **Installation**
+You can install the package via npm, yarn or pnpm:
+
+```bash
+npm install @baseapp-frontend/graphql
+# or
+yarn add @baseapp-frontend/graphql
+# or
+pnpm install @baseapp-frontend/graphql
+```
+
+## **Setup**
+In order to use this package you will need to:
+- create `relay.config.js` file at the root level:
+```ts
+  module.exports = require('@baseapp-frontend/graphql/relay.config.ts')
+```
+
+- add relay compiler configuration under `next.config.js`:
+  ```ts
+  const nextConfig = {
+    // ...
+    transpilePackages: [
+      // ...
+      '@baseapp-frontend/graphql', // make sure to add this package under `transpilePackages` as well
+    ],
+    compiler: {
+      relay: {
+        src: "./",
+        language: "typescript",
+        artifactDirectory: "__generated__",
+      },
+    },
+  }
+```
+
+In order to use common `Relay` features like `usePreloadedQuery` or `graphql` and to be able to create the generated files and download the graphql schema, you may need to install these additional dependencies (they're also present in the `@baseapp-frontend/graphql` dependencies, so make sure to install the same versions):
+
+- install dependecies
+```bash
+    yarn add react-relay@^16.1.0
+    yarn add -D relay-compiler@^16.1.0 @types/react-relay@^16.0.5
+```
+
+## **What is in here?**
+
+### **RelayProvider**
+
+This wrapper leverages the [RelayEnvironmentProvider](https://relay.dev/docs/api-reference/relay-environment-provider/#relayenvironmentprovider) from `react-relay` to supply a Relay environment throughout your application component tree.
+
+It uses `useEnvironment` from `config/environment` for dynamic Relay environment configuration.
+
+#### **Props**
+
+- `children` (required): The child components that will receive access to the Relay environment.
+
+#### **Usage**
+
+To utilize `RelayProvider`, wrap your application or specific components where Relay functionality is needed.
+
+- `RelayProvider` usage example inside the root layout:
+   ```tsx
+    import { RelayProvider } from '@baseapp-frontend/graphql';
+
+    const RootLayout: FC<PropsWithChildren> = ({ children }) => {
+      return (
+        <html lang="en">
+          <body>
+            <RelayProvider>
+              {children}
+            </RelayProvider>
+          </body>
+        </html>
+      )
+    }
+
+    export default RootLayout
+    ```
+
+### **withRelay**
+`withRelay` is a higher-order component for components that uses GraphQL preloaded queries.
+
+#### **Parameters**
+
+- `Component`: React component.
+- `fallback` (optional): A React element or string to display while the query is loading. Default to 'Loading...'.
+- `fetchPolicy` (optional): Defines the query fetching policy. Default to 'store-or-network'.
+
+#### **Usage**
+- `withRelay` usage example in a client component that receives a pre loaded query:
+   ```tsx
+    'use client'
+
+    import { FC } from 'react'
+
+    import { ComponentWithQueryRef, withRelay } from '@baseapp-frontend/graphql'
+
+    import { graphql, usePreloadedQuery } from 'react-relay'
+
+    import ClientComponentTestQueryNode, {
+      ClientComponentTestQuery,
+    } from '__generated__/ClientComponentTestQuery.graphql'
+
+    const ClientComponent: FC<ComponentWithQueryRef<ClientComponentTestQuery>> = ({
+      queryRef,
+    }) => {
+      const data = usePreloadedQuery(
+        graphql`
+          query ClientComponentTestQuery {
+            user {
+              id
+              name
+              bio
+            }
+          }
+        `,
+        queryRef,
+      )
+
+      return <h1>{data.user?.bio}</h1>
+    }
+
+    export default withRelay<
+      typeof ClientComponentTestQueryNode,
+      ClientComponentTestQuery
+    >(ClientComponent, { fallback: 'A different loading fallback', fetchPolicy: 'store-and-network' })
+  ```
+
+- A parent component that pre loads a query and passes it over to the `ClientComponent`:
+  ```tsx
+    import { loadSerializableQuery } from '@baseapp-frontend/graphql'
+
+    import ClientComponentTestQueryNode, {
+      ClientComponentTestQuery,
+    } from '__generated__/ClientComponentAboutArtistRegisterQuery.graphql'
+
+    import ClientComponent from './ClientComponent'
+
+    const ParentComponent = async () => {
+      const preloadedQuery = await loadSerializableQuery<
+        typeof ClientComponentTestQueryNode,
+        ClientComponentTestQuery
+      >(ClientComponentTestQueryNode.params, {})
+
+      return (
+        <div>
+          <ClientComponent preloadedQuery={preloadedQuery} />
+        </div>
+      )
+    }
+
+    export default ParentComponent
+  ```

--- a/packages/graphql/RelayProvider/index.tsx
+++ b/packages/graphql/RelayProvider/index.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { FC, PropsWithChildren } from 'react'
+
+import { RelayEnvironmentProvider } from 'react-relay'
+
+import { useEnvironment } from '../config/environment'
+
+const RelayProvider: FC<PropsWithChildren> = ({ children }) => {
+  const environment = useEnvironment()
+
+  return <RelayEnvironmentProvider environment={environment}>{children}</RelayEnvironmentProvider>
+}
+
+export default RelayProvider

--- a/packages/graphql/config/environment.ts
+++ b/packages/graphql/config/environment.ts
@@ -1,0 +1,197 @@
+import { useMemo } from 'react'
+
+import { ACCESS_COOKIE_NAME } from '@baseapp-frontend/utils/constants/cookie'
+
+import { createClient } from 'graphql-ws'
+import WebSocket from 'isomorphic-ws'
+import Cookies from 'js-cookie'
+import {
+  CacheConfig,
+  Environment,
+  GraphQLResponse,
+  Network,
+  Observable,
+  QueryResponseCache,
+  RecordSource,
+  RequestParameters,
+  Store,
+  UploadableMap,
+  Variables,
+} from 'relay-runtime'
+
+const CACHE_TTL = 5 * 1000 // 5 seconds, to resolve preloaded results
+
+type RequestVariables = {
+  method: string
+  headers: {
+    Accept: string
+    'Content-Type'?: string
+    Authorization: string
+  }
+}
+
+const getToken = async () => {
+  if (typeof window === typeof undefined) {
+    const { cookies: serverCookies } = await import('next/headers')
+    return serverCookies().get(ACCESS_COOKIE_NAME)?.value
+  }
+  return Cookies.get(ACCESS_COOKIE_NAME)
+}
+
+const getFetchOptions = async (
+  request: RequestParameters,
+  variables: Variables,
+  uploadables?: UploadableMap | null,
+) => {
+  const authToken = await getToken()
+  const requestVariables: RequestVariables = {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      Authorization: authToken ? `Token ${authToken}` : '',
+    },
+  }
+
+  if (uploadables) {
+    const formData = new FormData()
+    formData.append('query', request.text as string)
+    formData.append('variables', JSON.stringify(variables))
+    Object.entries(uploadables).forEach(([key, value]) => {
+      formData.append(key, value)
+    })
+    return {
+      ...requestVariables,
+      body: formData,
+    }
+  }
+
+  requestVariables.headers['Content-Type'] = 'application/json'
+  return {
+    ...requestVariables,
+    body: JSON.stringify({
+      query: request.text,
+      operationName: request.name,
+      operationKind: request.operationKind,
+      variables,
+    }),
+  }
+}
+
+export async function httpFetch(
+  request: RequestParameters,
+  variables: Variables,
+  cacheConfig?: CacheConfig,
+  uploadables?: UploadableMap | null,
+): Promise<GraphQLResponse> {
+  const fetchOptions = await getFetchOptions(request, variables, uploadables)
+
+  const response = await fetch(process.env.NEXT_PUBLIC_RELAY_ENDPOINT as string, fetchOptions)
+
+  const json = await response.json()
+
+  // GraphQL returns exceptions (for example, a missing required variable) in the "errors"
+  // property of the response. If any exceptions occurred when processing the request,
+  // throw an error to indicate to the developer what went wrong.
+  if (Array.isArray(json.errors)) {
+    throw new Error(
+      `Error fetching GraphQL query '${request.name}' with variables '${JSON.stringify(
+        variables,
+      )}': ${JSON.stringify(json.errors)}`,
+    )
+  }
+
+  return json
+}
+
+const wsClient = createClient({
+  url: process.env.NEXT_PUBLIC_WS_RELAY_ENDPOINT as string,
+  connectionParams: async () => {
+    const Authorization = Cookies.get('Authorization')
+    if (!Authorization) return {}
+    return { Authorization }
+  },
+  retryAttempts: Infinity,
+  webSocketImpl: WebSocket,
+})
+
+const websocketFetch = (request: RequestParameters, variables: Variables): Observable<any> =>
+  Observable.create((sink) => {
+    if (!request.text) {
+      return sink.error(new Error('Operation text cannot be empty'))
+    }
+    return wsClient.subscribe(
+      {
+        operationName: request.name,
+        query: request.text,
+        variables,
+      },
+      sink,
+    )
+  })
+
+function createNetwork(responseCache: QueryResponseCache) {
+  async function fetchResponse(
+    request: RequestParameters,
+    variables: Variables,
+    cacheConfig: CacheConfig,
+    uploadables?: UploadableMap | null,
+  ) {
+    const isQuery = request.operationKind === 'query'
+    const cacheKey = request.id ?? request.cacheID
+    const forceFetch = cacheConfig && cacheConfig.force
+    if (responseCache != null && isQuery && !forceFetch) {
+      const fromCache = responseCache.get(cacheKey, variables)
+      if (fromCache != null) {
+        return Promise.resolve(fromCache)
+      }
+    }
+
+    return httpFetch(request, variables, cacheConfig, uploadables)
+  }
+
+  const network = Network.create(fetchResponse, websocketFetch)
+  return network
+}
+
+function createQueryCache() {
+  return new QueryResponseCache({
+    size: 100,
+    ttl: CACHE_TTL,
+  })
+}
+
+const responseCacheByEnvironment = new WeakMap<Environment, QueryResponseCache>()
+
+function createEnvironment() {
+  const cache = createQueryCache()
+  const network = createNetwork(cache)
+  const store = new Store(RecordSource.create())
+
+  const environment = new Environment({
+    network,
+    store,
+    isServer: typeof window === typeof undefined,
+  })
+
+  responseCacheByEnvironment.set(environment, cache)
+
+  return environment
+}
+
+let relayEnvironment: Environment | null = null
+function initEnvironment() {
+  const environment = relayEnvironment ?? createEnvironment()
+  // For SSR always return new environment;
+  if (typeof window === typeof undefined) return environment
+  if (!relayEnvironment) relayEnvironment = environment
+  return relayEnvironment
+}
+
+export function useEnvironment() {
+  const env = useMemo(() => initEnvironment(), [relayEnvironment])
+  return env
+}
+
+export function getCacheByEnvironment(environment: Environment) {
+  return responseCacheByEnvironment.get(environment)
+}

--- a/packages/graphql/config/index.ts
+++ b/packages/graphql/config/index.ts
@@ -1,0 +1,6 @@
+export * from './environment'
+
+export { default as loadSerializableQuery } from './loadSerializableQuery'
+export type * from './loadSerializableQuery'
+
+export { default as useSerializablePreloadedQuery } from './useSerializablePreloadedQuery'

--- a/packages/graphql/config/loadSerializableQuery.ts
+++ b/packages/graphql/config/loadSerializableQuery.ts
@@ -1,0 +1,31 @@
+import { GraphQLResponse, OperationType, RequestParameters, VariablesOf } from 'relay-runtime'
+import { ConcreteRequest } from 'relay-runtime/lib/util/RelayConcreteNode'
+
+import { httpFetch } from './environment'
+
+export interface SerializablePreloadedQuery<
+  TRequest extends ConcreteRequest,
+  TQuery extends OperationType,
+> {
+  params: TRequest['params']
+  variables: VariablesOf<TQuery>
+  response: GraphQLResponse
+}
+
+// Call into raw network fetch to get serializable GraphQL query response
+// This response will be sent to the client to "warm" the QueryResponseCache
+// to avoid the client fetches.
+export default async function loadSerializableQuery<
+  TRequest extends ConcreteRequest,
+  TQuery extends OperationType,
+>(
+  params: RequestParameters,
+  variables: VariablesOf<TQuery>,
+): Promise<SerializablePreloadedQuery<TRequest, TQuery>> {
+  const response = await httpFetch(params, variables)
+  return {
+    params,
+    variables,
+    response,
+  }
+}

--- a/packages/graphql/config/useSerializablePreloadedQuery.ts
+++ b/packages/graphql/config/useSerializablePreloadedQuery.ts
@@ -1,0 +1,49 @@
+// Convert preloaded query object (with raw GraphQL Response) into
+// Relay's PreloadedQuery.
+import { useMemo } from 'react'
+
+import { PreloadFetchPolicy, PreloadedQuery } from 'react-relay'
+import { ConcreteRequest, Environment, OperationType } from 'relay-runtime'
+
+import { getCacheByEnvironment } from './environment'
+import { SerializablePreloadedQuery } from './loadSerializableQuery'
+
+function writePreloadedQueryToCache<TRequest extends ConcreteRequest, TQuery extends OperationType>(
+  preloadedQueryObject: SerializablePreloadedQuery<TRequest, TQuery>,
+  environment: Environment,
+) {
+  const cacheKey = preloadedQueryObject.params.id ?? preloadedQueryObject.params.cacheID
+  const responseCache = getCacheByEnvironment(environment)
+
+  responseCache?.set(cacheKey, preloadedQueryObject.variables, preloadedQueryObject.response)
+}
+
+// This hook convert serializable preloaded query
+// into Relay's PreloadedQuery object.
+// It is also writes this serializable preloaded query
+// into QueryResponseCache, so we the network layer
+// can use these cache results when fetching data
+// in `usePreloadedQuery`.
+export default function useSerializablePreloadedQuery<
+  TRequest extends ConcreteRequest,
+  TQuery extends OperationType,
+>(
+  environment: Environment,
+  preloadQuery: SerializablePreloadedQuery<TRequest, TQuery>,
+  fetchPolicy: PreloadFetchPolicy = 'store-or-network',
+): PreloadedQuery<TQuery> {
+  useMemo(() => {
+    writePreloadedQueryToCache(preloadQuery, environment)
+  }, [preloadQuery])
+
+  return {
+    environment,
+    fetchKey: preloadQuery.params.id ?? preloadQuery.params.cacheID,
+    fetchPolicy,
+    isDisposed: false,
+    name: preloadQuery.params.name,
+    kind: 'PreloadedQuery',
+    variables: preloadQuery.variables,
+    dispose: () => {},
+  }
+}

--- a/packages/graphql/index.ts
+++ b/packages/graphql/index.ts
@@ -1,0 +1,6 @@
+export * from './config'
+
+export { default as RelayProvider } from './RelayProvider'
+
+export { default as withRelay } from './withRelay'
+export type * from './withRelay/types'

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@baseapp-frontend/graphql",
+  "description": "GraphQL configurations and utilities",
+  "version": "1.0.0",
+  "main": "./dist/index.ts",
+  "module": "./dist/index.mjs",
+  "files": [
+    "relay.config.ts"
+  ],
+  "scripts": {
+    "build": "tsc --build",
+    "dev": "tsc --watch",
+    "lint": "eslint . --ext .tsx --ext .ts && tsc --noEmit",
+    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
+  },
+  "devDependencies": {
+    "@baseapp-frontend/config": "*",
+    "@baseapp-frontend/tsconfig": "*",
+    "@types/js-cookie": "^3.0.6",
+    "@types/react": "^18.2.24",
+    "@types/react-dom": "^18.2.10",
+    "@types/react-relay": "^16.0.5",
+    "@types/relay-runtime": "^14.1.19",
+    "relay-compiler": "^16.1.0",
+    "typescript": "^5.1.3"
+  },
+  "dependencies": {
+    "@baseapp-frontend/utils": "*",
+    "graphql": "^16.8.1",
+    "graphql-ws": "^5.14.2",
+    "isomorphic-ws": "^5.0.0",
+    "js-cookie": "^3.0.5",
+    "next": "^14.0.4",
+    "react": "^18.2.0",
+    "react-relay": "^16.1.0",
+    "relay-runtime": "^16.1.0"
+  },
+  "resolutions": {
+    "@types/react": "^18.2.12"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/silverlogic/baseapp-frontend.git",
+    "directory": "packages/graphql"
+  },
+  "bugs": {
+    "url": "https://github.com/silverlogic/baseapp-frontend/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/graphql/relay.config.ts
+++ b/packages/graphql/relay.config.ts
@@ -1,0 +1,7 @@
+module.exports = {
+  src: './',
+  schema: './schema.graphql',
+  exclude: ['**/.next/**', '**/node_modules/**', '**/__generated__/**'],
+  language: 'typescript',
+  artifactDirectory: './__generated__',
+}

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@baseapp-frontend/tsconfig/core.json",
+  "include": ["**/*.ts", "**/*.tsx", "**/*.d.ts", ".eslintrc.js", "*.ts", "*.tsx"],
+  "exclude": ["node_modules", "./relay.config.js"]
+}

--- a/packages/graphql/withRelay/index.tsx
+++ b/packages/graphql/withRelay/index.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { FC, Suspense } from 'react'
+
+import { useRelayEnvironment } from 'react-relay'
+import { ConcreteRequest, OperationType } from 'relay-runtime'
+
+import { useSerializablePreloadedQuery } from '../config'
+import { ComponentWithPreloadedQuery, ComponentWithQueryRef, WithRelayOptions } from './types'
+
+/**
+ * Relay HOC for components that uses preloaded queries.
+ *
+ * @description
+ * This is a **BaseApp** feature.
+ *
+ * If you believe your changes should be in the BaseApp, please read the **CONTRIBUTING.md** guide.
+ */
+const withRelay =
+  <QueryNode extends ConcreteRequest, Query extends OperationType, Props = {}>(
+    Component: FC<Props & ComponentWithQueryRef<Query>>,
+    { fallback = 'Loading...', fetchPolicy = 'store-or-network' }: WithRelayOptions = {},
+  ) =>
+  (props: Props & ComponentWithPreloadedQuery<QueryNode, Query>) => {
+    const { preloadedQuery } = props
+    const environment = useRelayEnvironment()
+    const queryRef = useSerializablePreloadedQuery(environment, preloadedQuery, fetchPolicy)
+
+    return (
+      <Suspense fallback={fallback}>
+        <Component {...props} queryRef={queryRef} />
+      </Suspense>
+    )
+  }
+
+export default withRelay

--- a/packages/graphql/withRelay/types.ts
+++ b/packages/graphql/withRelay/types.ts
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react'
+
+import { PreloadFetchPolicy, PreloadedQuery } from 'react-relay'
+import { ConcreteRequest, OperationType } from 'relay-runtime'
+
+import { SerializablePreloadedQuery } from '../config/loadSerializableQuery'
+
+export type WithRelayOptions = {
+  fallback?: ReactNode
+  fetchPolicy?: PreloadFetchPolicy
+}
+
+export interface ComponentWithQueryRef<Query extends OperationType> {
+  queryRef: PreloadedQuery<Query, Record<string, unknown>>
+}
+
+export interface ComponentWithPreloadedQuery<
+  QueryNode extends ConcreteRequest,
+  Query extends OperationType,
+> {
+  preloadedQuery: SerializablePreloadedQuery<QueryNode, Query>
+}

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/utils
 
+## 1.3.7
+
+### Patch Changes
+
+- Refactor `setFormApiErrors` so it only sets the form's errors if the API response is appropriate and if the field matches the form key. 
+
 ## 1.3.6
 
 ### Patch Changes

--- a/packages/utils/functions/form/setFormApiErrors/__tests__/setFormApiErrors.test.ts
+++ b/packages/utils/functions/form/setFormApiErrors/__tests__/setFormApiErrors.test.ts
@@ -6,13 +6,22 @@ describe('setFormApiErrors', () => {
 
   beforeEach(() => {
     mockForm = {
+      getValues: jest.fn().mockImplementation(
+        (fieldKey: string) =>
+          ({
+            name: 'John',
+            age: 20,
+          }[fieldKey]),
+      ),
       setError: jest.fn(),
     }
 
     mockError = {
       response: {
-        name: ['Name is required'],
-        age: ['Age should be a number'],
+        data: {
+          name: ['Name is required'],
+          age: ['Age should be a number'],
+        },
       },
     }
   })
@@ -35,5 +44,35 @@ describe('setFormApiErrors', () => {
     setFormApiErrors(mockForm, mockError)
 
     expect(mockForm.setError).not.toHaveBeenCalled()
+  })
+
+  it('should not set any errors if the data error response is not an object', () => {
+    mockError.response.data = 'This is not an object with a data property'
+    setFormApiErrors(mockForm, mockError)
+
+    expect(mockForm.setError).not.toHaveBeenCalled()
+  })
+
+  it('should not set errors for fields that do not exist on the form', () => {
+    mockError.response.data = {
+      name: ['Name is required'],
+      age: ['Age should be a number'],
+      address: ['Address is required'],
+    }
+
+    setFormApiErrors(mockForm, mockError)
+
+    expect(mockForm.setError).toHaveBeenCalledWith('name', {
+      type: 'manual',
+      message: 'Name is required',
+    })
+    expect(mockForm.setError).toHaveBeenCalledWith('age', {
+      type: 'manual',
+      message: 'Age should be a number',
+    })
+    expect(mockForm.setError).not.toHaveBeenCalledWith('address', {
+      type: 'manual',
+      message: 'Address is required',
+    })
   })
 })

--- a/packages/utils/functions/form/setFormApiErrors/index.ts
+++ b/packages/utils/functions/form/setFormApiErrors/index.ts
@@ -1,8 +1,16 @@
+import entries from 'lodash/entries'
+import head from 'lodash/head'
+import map from 'lodash/map'
 import { FieldValues, Path, UseFormReturn } from 'react-hook-form'
 
 export const setFormApiErrors = <T extends FieldValues>(form: UseFormReturn<T>, err: any) => {
-  Object.entries(err?.response ?? {}).map(
-    ([key, errors]) =>
-      form.setError(key as Path<T>, { type: 'manual', message: (errors as string[])[0] }), // we asume that there will be only one error per field
-  )
+  if (err.response?.data && typeof err.response.data === 'object') {
+    map(entries(err.response.data), ([key, errors]) => {
+      const fieldKey = key as Path<T>
+      const errorMessage = head(errors as string[])
+      if (!!form.getValues(fieldKey) && typeof errorMessage === 'string') {
+        form.setError(fieldKey, { type: 'manual', message: errorMessage })
+      }
+    })
+  }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/utils",
   "description": "Util functions, constants and types.",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1105,6 +1105,13 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
+"@babel/runtime@^7.0.0":
+  version "7.23.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.6.tgz#c05e610dc228855dc92ef1b53d07389ed8ab521d"
+  integrity sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.1", "@babel/runtime@^7.20.7", "@babel/runtime@^7.22.6", "@babel/runtime@^7.23.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.23.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.1.tgz#72741dc4d413338a91dcb044a86f3c0bc402646d"
@@ -2294,6 +2301,11 @@
   resolved "https://registry.yarnpkg.com/@next/env/-/env-13.5.4.tgz#777c3af16de2cf2f611b6c8126910062d13d222c"
   integrity sha512-LGegJkMvRNw90WWphGJ3RMHMVplYcOfRWf2Be3td3sUa+1AaxmsYyANsA+znrGCBjXJNi4XAQlSoEfUxs/4kIQ==
 
+"@next/env@14.0.4":
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-14.0.4.tgz#d5cda0c4a862d70ae760e58c0cd96a8899a2e49a"
+  integrity sha512-irQnbMLbUNQpP1wcE5NstJtbuA/69kRfzBrpAD7Gsn8zm/CY6YQYc3HQBz8QPxwISG26tIm5afvvVbu508oBeQ==
+
 "@next/eslint-plugin-next@13.5.4", "@next/eslint-plugin-next@^13.1.6":
   version "13.5.4"
   resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-13.5.4.tgz#ec70af509f07dc4e545df25834ac94d2c341c36a"
@@ -2321,6 +2333,11 @@
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.4.tgz#241957774fef3f876dc714cfc0ca6f00f561737e"
   integrity sha512-Df8SHuXgF1p+aonBMcDPEsaahNo2TCwuie7VXED4FVyECvdXfRT9unapm54NssV9tF3OQFKBFOdlje4T43VO0w==
 
+"@next/swc-darwin-arm64@14.0.4":
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.4.tgz#27b1854c2cd04eb1d5e75081a1a792ad91526618"
+  integrity sha512-mF05E/5uPthWzyYDyptcwHptucf/jj09i2SXBPwNzbgBNc+XnwzrL0U6BmPjQeOL+FiB+iG1gwBeq7mlDjSRPg==
+
 "@next/swc-darwin-x64@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.4.tgz#e7dc63cd2ac26d15fb84d4d2997207fb9ba7da0f"
@@ -2330,6 +2347,11 @@
   version "13.5.4"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.4.tgz#fa11bb97bf06cd45cbd554354b46bf93e22c025b"
   integrity sha512-siPuUwO45PnNRMeZnSa8n/Lye5ZX93IJom9wQRB5DEOdFrw0JjOMu1GINB8jAEdwa7Vdyn1oJ2xGNaQpdQQ9Pw==
+
+"@next/swc-darwin-x64@14.0.4":
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.4.tgz#9940c449e757d0ee50bb9e792d2600cc08a3eb3b"
+  integrity sha512-IZQ3C7Bx0k2rYtrZZxKKiusMTM9WWcK5ajyhOZkYYTCc8xytmwSzR1skU7qLgVT/EY9xtXDG0WhY6fyujnI3rw==
 
 "@next/swc-freebsd-x64@12.3.4":
   version "12.3.4"
@@ -2351,6 +2373,11 @@
   resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.4.tgz#dd3a482cd6871ed23b049066a0f3c4c2f955dc88"
   integrity sha512-l/k/fvRP/zmB2jkFMfefmFkyZbDkYW0mRM/LB+tH5u9pB98WsHXC0WvDHlGCYp3CH/jlkJPL7gN8nkTQVrQ/2w==
 
+"@next/swc-linux-arm64-gnu@14.0.4":
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.4.tgz#0eafd27c8587f68ace7b4fa80695711a8434de21"
+  integrity sha512-VwwZKrBQo/MGb1VOrxJ6LrKvbpo7UbROuyMRvQKTFKhNaXjUmKTu7wxVkIuCARAfiI8JpaWAnKR+D6tzpCcM4w==
+
 "@next/swc-linux-arm64-musl@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.4.tgz#4d1db6de6dc982b974cd1c52937111e3e4a34bd3"
@@ -2360,6 +2387,11 @@
   version "13.5.4"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.4.tgz#ed6d7abaf5712cff2752ce5300d6bacc6aff1b18"
   integrity sha512-YYGb7SlLkI+XqfQa8VPErljb7k9nUnhhRrVaOdfJNCaQnHBcvbT7cx/UjDQLdleJcfyg1Hkn5YSSIeVfjgmkTg==
+
+"@next/swc-linux-arm64-musl@14.0.4":
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.4.tgz#2b0072adb213f36dada5394ea67d6e82069ae7dd"
+  integrity sha512-8QftwPEW37XxXoAwsn+nXlodKWHfpMaSvt81W43Wh8dv0gkheD+30ezWMcFGHLI71KiWmHK5PSQbTQGUiidvLQ==
 
 "@next/swc-linux-x64-gnu@12.3.4":
   version "12.3.4"
@@ -2371,6 +2403,11 @@
   resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.4.tgz#977a040388e8a685a3a85e0dbdff90a4ee2a7189"
   integrity sha512-uE61vyUSClnCH18YHjA8tE1prr/PBFlBFhxBZis4XBRJoR+txAky5d7gGNUIbQ8sZZ7LVkSVgm/5Fc7mwXmRAg==
 
+"@next/swc-linux-x64-gnu@14.0.4":
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.0.4.tgz#68c67d20ebc8e3f6ced6ff23a4ba2a679dbcec32"
+  integrity sha512-/s/Pme3VKfZAfISlYVq2hzFS8AcAIOTnoKupc/j4WlvF6GQ0VouS2Q2KEgPuO1eMBwakWPB1aYFIA4VNVh667A==
+
 "@next/swc-linux-x64-musl@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.4.tgz#187a883ec09eb2442a5ebf126826e19037313c61"
@@ -2380,6 +2417,11 @@
   version "13.5.4"
   resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.4.tgz#3e29a0ad8efc016196c3a120da04397eea328b2a"
   integrity sha512-qVEKFYML/GvJSy9CfYqAdUexA6M5AklYcQCW+8JECmkQHGoPxCf04iMh7CPR7wkHyWWK+XLt4Ja7hhsPJtSnhg==
+
+"@next/swc-linux-x64-musl@14.0.4":
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.0.4.tgz#67cd81b42fb2caf313f7992fcf6d978af55a1247"
+  integrity sha512-m8z/6Fyal4L9Bnlxde5g2Mfa1Z7dasMQyhEhskDATpqr+Y0mjOBZcXQ7G5U+vgL22cI4T7MfvgtrM2jdopqWaw==
 
 "@next/swc-win32-arm64-msvc@12.3.4":
   version "12.3.4"
@@ -2391,6 +2433,11 @@
   resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.4.tgz#18a236c3fe5a48d24b56d939e6a05488bb682b7e"
   integrity sha512-mDSQfqxAlfpeZOLPxLymZkX0hYF3juN57W6vFHTvwKlnHfmh12Pt7hPIRLYIShk8uYRsKPtMTth/EzpwRI+u8w==
 
+"@next/swc-win32-arm64-msvc@14.0.4":
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.4.tgz#be06585906b195d755ceda28f33c633e1443f1a3"
+  integrity sha512-7Wv4PRiWIAWbm5XrGz3D8HUkCVDMMz9igffZG4NB1p4u1KoItwx9qjATHz88kwCEal/HXmbShucaslXCQXUM5w==
+
 "@next/swc-win32-ia32-msvc@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.4.tgz#cb50c08f0e40ead63642a7f269f0c8254261f17c"
@@ -2401,6 +2448,11 @@
   resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.4.tgz#255132243ab6fb20d3c7c92a585e2c4fa50368fe"
   integrity sha512-aoqAT2XIekIWoriwzOmGFAvTtVY5O7JjV21giozBTP5c6uZhpvTWRbmHXbmsjZqY4HnEZQRXWkSAppsIBweKqw==
 
+"@next/swc-win32-ia32-msvc@14.0.4":
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.4.tgz#e76cabefa9f2d891599c3d85928475bd8d3f6600"
+  integrity sha512-zLeNEAPULsl0phfGb4kdzF/cAVIfaC7hY+kt0/d+y9mzcZHsMS3hAS829WbJ31DkSlVKQeHEjZHIdhN+Pg7Gyg==
+
 "@next/swc-win32-x64-msvc@12.3.4":
   version "12.3.4"
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.4.tgz#d28ea15a72cdcf96201c60a43e9630cd7fda168f"
@@ -2410,6 +2462,11 @@
   version "13.5.4"
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.4.tgz#cc542907b55247c5634d9a8298e1c143a1847e25"
   integrity sha512-cyRvlAxwlddlqeB9xtPSfNSCRy8BOa4wtMo0IuI9P7Y0XT2qpDrpFKRyZ7kUngZis59mPVla5k8X1oOJ8RxDYg==
+
+"@next/swc-win32-x64-msvc@14.0.4":
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.4.tgz#e74892f1a9ccf41d3bf5979ad6d3d77c07b9cba1"
+  integrity sha512-yEh2+R8qDlDCjxVpzOTEpBLQTEFAcP2A8fUFLaWNap9GitYKkKv1//y2S6XY6zsR4rCOPRpU7plYDR+az2n30A==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -4019,6 +4076,11 @@
   resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-3.0.4.tgz#23475b6d3b03acc84192e7c24da88eb38c1039ef"
   integrity sha512-vMMnFF+H5KYqdd/myCzq6wLDlPpteJK+jGFgBus3Da7lw+YsDmx2C8feGTzY2M3Fo823yON+HC2CL240j4OV+w==
 
+"@types/js-cookie@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-3.0.6.tgz#a04ca19e877687bd449f5ad37d33b104b71fdf95"
+  integrity sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==
+
 "@types/jsdom@^20.0.0":
   version "20.0.1"
   resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-20.0.1.tgz#07c14bc19bd2f918c1929541cdaacae894744808"
@@ -4145,6 +4207,14 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-relay@^16.0.5":
+  version "16.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react-relay/-/react-relay-16.0.5.tgz#3a67c0b05033325aa2361aa499d5e779704275ac"
+  integrity sha512-iQjijrgYN3SeOxzr2O4bh4ez9xajj1KLwgakui5VKiw/f9r5IISMB7bMq/KdlNO5W3p8qyB09h24iIcO3jMz/g==
+  dependencies:
+    "@types/react" "*"
+    "@types/relay-runtime" "*"
+
 "@types/react-transition-group@^4.4.6":
   version "4.4.7"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.7.tgz#bf69f269d74aa78b99097673ca6dd6824a68ef1c"
@@ -4153,9 +4223,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@>=16", "@types/react@^18.2.21", "@types/react@^18.2.24":
-  version "18.2.25"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.25.tgz#99fa44154132979e870ff409dc5b6e67f06f0199"
-  integrity sha512-24xqse6+VByVLIr+xWaQ9muX1B4bXJKXBbjszbld/UEDslGLY53+ZucF44HCmLbMPejTzGG9XgR+3m2/Wqu1kw==
+  version "18.2.44"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.44.tgz#13104f12d30545f4cea11b8d81809bec316fe175"
+  integrity sha512-i7rRdWr8XsAdqVXU05NSlash6DapNLVoNnsfWfOYN2BUIzkH2YgagIeOuUK1fNmJ08iGHpt2enwi0beaBR+ldA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -4169,6 +4239,11 @@
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
+
+"@types/relay-runtime@*", "@types/relay-runtime@^14.1.19":
+  version "14.1.19"
+  resolved "https://registry.yarnpkg.com/@types/relay-runtime/-/relay-runtime-14.1.19.tgz#aa343363d15e7ff9a963cb0b28fd5f88ee7e44d4"
+  integrity sha512-j7JlgOGqpEJUjB4/xJ3tktb0eERj036fF1cdBFJ4ykzvANVCIPylJxxYK9Wi7V07qOmcGYB7DhI5R6k6LorZfQ==
 
 "@types/scheduler@*":
   version "0.16.4"
@@ -4863,6 +4938,11 @@ arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==
+
+asap@~2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
 asn1.js@^5.2.0:
   version "5.4.1"
@@ -5907,6 +5987,13 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
+cross-fetch@^3.1.5:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
+  integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
+  dependencies:
+    node-fetch "^2.6.12"
 
 cross-spawn@^5.1.0:
   version "5.1.0"
@@ -7173,6 +7260,24 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fbjs-css-vars@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
+  integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
+
+fbjs@^3.0.2:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-3.0.5.tgz#aa0edb7d5caa6340011790bd9249dbef8a81128d"
+  integrity sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==
+  dependencies:
+    cross-fetch "^3.1.5"
+    fbjs-css-vars "^1.0.0"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^1.0.35"
+
 fd-slicer@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
@@ -7648,7 +7753,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.5, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.5, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -7662,6 +7767,16 @@ graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
+
+graphql-ws@^5.14.2:
+  version "5.14.2"
+  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.14.2.tgz#7db6f6138717a544d9480f0213f65f2841ed1c52"
+  integrity sha512-LycmCwhZ+Op2GlHz4BZDsUYHKRiiUz+3r9wbhBATMETNlORQJAaFlAgTFoeRh6xQoQegwYwIylVD1Qns9/DA3w==
+
+graphql@^16.8.1:
+  version "16.8.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.1.tgz#1930a965bef1170603702acdb68aedd3f3cf6f07"
+  integrity sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==
 
 gunzip-maybe@^1.4.2:
   version "1.4.2"
@@ -8355,6 +8470,11 @@ isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
+
+isomorphic-ws@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz#e5529148912ecb9b451b46ed44d53dae1ce04bbf"
+  integrity sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
@@ -10049,6 +10169,30 @@ next@12.3.4, next@^12.2.4:
     "@next/swc-win32-ia32-msvc" "12.3.4"
     "@next/swc-win32-x64-msvc" "12.3.4"
 
+next@^14.0.4:
+  version "14.0.4"
+  resolved "https://registry.yarnpkg.com/next/-/next-14.0.4.tgz#bf00b6f835b20d10a5057838fa2dfced1d0d84dc"
+  integrity sha512-qbwypnM7327SadwFtxXnQdGiKpkuhaRLE2uq62/nRul9cj9KhQ5LhHmlziTNqUidZotw/Q1I9OjirBROdUJNgA==
+  dependencies:
+    "@next/env" "14.0.4"
+    "@swc/helpers" "0.5.2"
+    busboy "1.6.0"
+    caniuse-lite "^1.0.30001406"
+    graceful-fs "^4.2.11"
+    postcss "8.4.31"
+    styled-jsx "5.1.1"
+    watchpack "2.4.0"
+  optionalDependencies:
+    "@next/swc-darwin-arm64" "14.0.4"
+    "@next/swc-darwin-x64" "14.0.4"
+    "@next/swc-linux-arm64-gnu" "14.0.4"
+    "@next/swc-linux-arm64-musl" "14.0.4"
+    "@next/swc-linux-x64-gnu" "14.0.4"
+    "@next/swc-linux-x64-musl" "14.0.4"
+    "@next/swc-win32-arm64-msvc" "14.0.4"
+    "@next/swc-win32-ia32-msvc" "14.0.4"
+    "@next/swc-win32-x64-msvc" "14.0.4"
+
 no-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
@@ -10074,7 +10218,7 @@ node-fetch-native@^1.4.0:
   resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.4.0.tgz#fbe8ac033cb6aa44bd106b5e4fd2b6277ba70fa1"
   integrity sha512-F5kfEj95kX8tkDhUCYdV8dg3/8Olx/94zB8+ZNthFs6Bz31UpUi8Xh40TN3thLwXgrwXry1pEg9lJ++tLWTcqA==
 
-node-fetch@^2.0.0:
+node-fetch@^2.0.0, node-fetch@^2.6.12:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -10158,12 +10302,17 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
+nullthrows@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
+  integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
+
 nwsapi@^2.2.0, nwsapi@^2.2.2:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.7.tgz#738e0707d3128cb750dddcfe90e4610482df0f30"
   integrity sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==
 
-object-assign@^4.1.1:
+object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -10763,6 +10912,13 @@ progress@^2.0.1:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
+  dependencies:
+    asap "~2.0.3"
+
 prompts@^2.0.1, prompts@^2.4.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
@@ -11037,6 +11193,17 @@ react-refresh@^0.11.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
+react-relay@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-16.1.0.tgz#de363f52d49bd01a8543c5d515cc034f97835483"
+  integrity sha512-qwm5PC+Vwy+qzs+Ob/PKs3YAWZOK2jm87GaMa44pHGR62ENS6xpFGXsANKAvFas1CUJ75yaexuGRO6z7RPnk8w==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    fbjs "^3.0.2"
+    invariant "^2.2.4"
+    nullthrows "^1.1.1"
+    relay-runtime "16.1.0"
+
 react-remove-scroll-bar@^2.3.3:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz#53e272d7a5cb8242990c7f144c44d8bd8ab5afd9"
@@ -11270,6 +11437,20 @@ relateurl@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
+
+relay-compiler@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-16.1.0.tgz#57b08740f415a90d1ac6cdcf12ba747fa30cdfb4"
+  integrity sha512-ZceB9u0Zx5/6VJwRViaGwZEUsEY/wqdbxPs7AD2/udZYabRae5az97MU9XZ3p4zIeZhR+y9y2+KLdXuoECeLvA==
+
+relay-runtime@16.1.0, relay-runtime@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-16.1.0.tgz#7ea5fa0e5964069f1bcfe802a41a20f92560e704"
+  integrity sha512-SM5MP4ETxTtYrXya5ceAEF3XuVzlku48+YyaxZkTnXG/FUvE2QfIxkZ5P2Q/j33Eo9tfrcl4UfZoSkx6IbQ37Q==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    fbjs "^3.0.2"
+    invariant "^2.2.4"
 
 remark-external-links@^8.0.0:
   version "8.0.0"
@@ -11594,7 +11775,7 @@ set-function-name@^2.0.0, set-function-name@^2.0.1:
     functions-have-names "^1.2.3"
     has-property-descriptors "^1.0.0"
 
-setimmediate@^1.0.4:
+setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
@@ -12555,6 +12736,11 @@ typescript@^5.1.3:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+
+ua-parser-js@^1.0.35:
+  version "1.0.37"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.37.tgz#b5dc7b163a5c1f0c510b08446aed4da92c46373f"
+  integrity sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
* `authentication` package update - `v1.2.3`
  - Add `enableFormApiErrors` option to all the hooks that were using `setFormApiErrors`. It now conditionally sets form errors based on the API response.
  - Add the `mode` option to the `useSignUp` hook.

* `graphql` package creation - `v1.0.0`
  - Creates the `graphql` package.

* `utils` package update - `v1.3.7`
  - Refactor `setFormApiErrors` so it only sets the form's errors if the API response is appropriate and if the field matches the form key. 
  
* `config` package update - `v2.1.1`
  - Include `relay.config.js` in the `ignorePatterns` list.