### PR TITLE
BA: emit logout event

### DIFF
--- a/packages/authentication/CHANGELOG.md
+++ b/packages/authentication/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Patch Changes
 
-- emitLogoutEvent
-- Add `emitLogoutEvent` option to the `useLogout` hook. It can conditionally emit the `LOGOUT_EVENT`. That's useful when you have subscribed to that event and want to execute some action after the event is triggered.
+- Add `emitLogoutEvent` option to the `useLogout` hook. By default, it will emit the `LOGOUT_EVENT`. That's useful when you have subscribed to that event and want to execute some action after the event is triggered.
 - Updated dependencies
   - @baseapp-frontend/utils@1.4.2
 

--- a/packages/authentication/CHANGELOG.md
+++ b/packages/authentication/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @baseapp-frontend/authentication
 
+## 1.2.5
+
+### Patch Changes
+
+- emitLogoutEvent
+- Add `emitLogoutEvent` option to the `useLogout` hook. It can conditionally emit the `LOGOUT_EVENT`. That's useful when you have subscribed to that event and want to execute some action after the event is triggered.
+- Updated dependencies
+  - @baseapp-frontend/utils@1.4.2
+
 ## 1.2.4
 
 ### Patch Changes

--- a/packages/authentication/modules/access/useLogout/__tests__/useLogout.test.tsx
+++ b/packages/authentication/modules/access/useLogout/__tests__/useLogout.test.tsx
@@ -1,4 +1,5 @@
 import { ComponentWithProviders, renderHook } from '@baseapp-frontend/test'
+import { LOGOUT_EVENT, eventEmitter } from '@baseapp-frontend/utils'
 
 import Cookies from 'js-cookie'
 
@@ -39,5 +40,16 @@ describe('useLogout hook', () => {
     result.current.logout()
 
     expect(mockOnLogout).toHaveBeenCalled()
+  })
+
+  it('should emit the logout event if the flag emitLogoutEvent is set to true', () => {
+    const emitSpy = jest.spyOn(eventEmitter, 'emit')
+    const { result } = renderHook(() => useLogout({ emitLogoutEvent: true }), {
+      wrapper: ComponentWithProviders,
+    })
+
+    result.current.logout()
+
+    expect(emitSpy).toHaveBeenCalledWith(LOGOUT_EVENT)
   })
 })

--- a/packages/authentication/modules/access/useLogout/index.ts
+++ b/packages/authentication/modules/access/useLogout/index.ts
@@ -1,4 +1,9 @@
-import { ACCESS_COOKIE_NAME, REFRESH_COOKIE_NAME } from '@baseapp-frontend/utils'
+import {
+  ACCESS_COOKIE_NAME,
+  LOGOUT_EVENT,
+  REFRESH_COOKIE_NAME,
+  eventEmitter,
+} from '@baseapp-frontend/utils'
 
 import { useQueryClient } from '@tanstack/react-query'
 import Cookies from 'js-cookie'
@@ -11,6 +16,7 @@ const useLogout = ({
   cookieName = ACCESS_COOKIE_NAME,
   refreshCookieName = REFRESH_COOKIE_NAME,
   onLogout,
+  emitLogoutEvent = true,
 }: ILogoutOptions = {}) => {
   const queryClient = useQueryClient()
 
@@ -20,6 +26,9 @@ const useLogout = ({
     queryClient.resetQueries(USER_API_KEY.getUser())
     queryClient.resetQueries(MFA_API_KEY.default)
     onLogout?.()
+    if (emitLogoutEvent) {
+      eventEmitter.emit(LOGOUT_EVENT)
+    }
   }
 
   return {

--- a/packages/authentication/modules/access/useLogout/types.ts
+++ b/packages/authentication/modules/access/useLogout/types.ts
@@ -2,4 +2,5 @@ import { ICookieName } from '../../../types/auth'
 
 export interface ILogoutOptions extends ICookieName {
   onLogout?: () => void
+  emitLogoutEvent?: boolean
 }

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/authentication",
   "description": "Authentication modules.",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/utils
 
+## 1.4.2
+
+### Patch Changes
+
+- Add `'./functions/events'` barrel file.
+
 ## 1.4.1
 
 ### Patch Changes

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -8,6 +8,7 @@ export * from './constants/zod'
 
 export * from './functions/api'
 export * from './functions/axios'
+export * from './functions/events'
 export * from './functions/form'
 export * from './functions/string'
 export * from './functions/token'

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/utils",
   "description": "Util functions, constants and types.",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {


### PR DESCRIPTION
* `authentication` package update - `v1.2.5`
  - Add `emitLogoutEvent` option to the `useLogout` hook. By default, it will emit the `LOGOUT_EVENT`. That's useful when you have subscribed to that event and want to execute some action after the event is triggered.

* `utils` package update - `v1.4.2`
  - Add `'./functions/events'` barrel file.