### PR TITLE
BA: remove barrel file imports from getUser

### DIFF
--- a/packages/authentication/CHANGELOG.md
+++ b/packages/authentication/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/authentication
 
+## 1.2.6
+
+### Patch Changes
+
+- Remove the import from barrel files inside the `getUser` function.
+- This has become necessary because we are not eliminating not used code that comes with the barrel file, and functions like `getUser` can be executed in environments that do not support some features that are being exported in the same barrel file, like `useDebounce`.
+
 ## 1.2.5
 
 ### Patch Changes

--- a/packages/authentication/modules/user/getUser/index.ts
+++ b/packages/authentication/modules/user/getUser/index.ts
@@ -1,4 +1,5 @@
-import { ACCESS_COOKIE_NAME, decodeJWT, getToken } from '@baseapp-frontend/utils'
+import { ACCESS_COOKIE_NAME } from '@baseapp-frontend/utils/constants/cookie'
+import { decodeJWT, getToken } from '@baseapp-frontend/utils/functions/token'
 import { IJWTContent } from '@baseapp-frontend/utils/types/jwt'
 
 import { IUser } from '../../../types/user'

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/authentication",
   "description": "Authentication modules.",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {


### PR DESCRIPTION
* `authentication` package update - `v1.2.6`
  - Remove the import from barrel files inside the `getUser` function.
  - This has become necessary because we are not eliminating not used code that comes with the barrel file, and functions like `getUser` can be executed in environments that do not support some features that are being exported in the same barrel file, like `useDebounce`.
