### PR TITLE
BA: flexibilize withController types

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,10 +1,17 @@
 # @baseapp-frontend/utils
 
+## 1.4.4
+
+### Patch Changes
+
+- Make `OptionalActions` types inside `withController` more flexible.
+
+
 ## 1.4.3
 
 ### Patch Changes
 
-- Improve `OptionalActions` types inside `withController`
+- Improve `OptionalActions` types inside `withController`.
 
 ## 1.4.2
 

--- a/packages/utils/functions/form/withController/types.ts
+++ b/packages/utils/functions/form/withController/types.ts
@@ -3,8 +3,8 @@ import { ChangeEventHandler, FocusEventHandler } from 'react'
 import { FormControl } from '../../../types/form'
 
 type OptionalActions = {
-  onChange?: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>
-  onBlur?: FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>
+  onChange?: (value: any) => void | ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>
+  onBlur?: (value?: any) => void | FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>
 }
 
 export type WithControllerProps<T> = FormControl & T & OptionalActions

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/utils",
   "description": "Util functions, constants and types.",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {


### PR DESCRIPTION
* `utils` package update - `v1.4.4`
  - Make `OptionalActions` types inside `withController` more flexible.