### PR TITLE
Fix refresh token flow for multipart requests

### DIFF
--- a/packages/authentication/CHANGELOG.md
+++ b/packages/authentication/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @baseapp-frontend/authentication
 
+## 2.0.0
+
+### Major Changes
+
+- The getUser function is async now, handle accordingly.
+- Some types were added to make testing easier.
+
+### Patch Changes
+
+- Updated dependencies [2300f2d]
+  - @baseapp-frontend/utils@2.0.0
+
 ## 1.2.6
 
 ### Patch Changes

--- a/packages/authentication/modules/user/getUser/__tests__/getUser.test.ts
+++ b/packages/authentication/modules/user/getUser/__tests__/getUser.test.ts
@@ -6,18 +6,18 @@ import getUser from '../index'
 import jwt from './fixtures/jwt.json'
 
 describe('getUser', () => {
-  it('should return the user from the JWT cookie', () => {
+  it('should return the user from the JWT cookie', async () => {
     ;(Cookies.get as CookiesGetByNameFn) = jest.fn(() => jwt.token)
-    const user = getUser()
+    const user = await getUser()
 
     expect(user?.email).toBe('user@company.com')
     expect(user?.firstName).toBe('John')
     expect(user?.lastName).toBe('Doe')
   })
 
-  it('should return null if the JWT cookie is not set', () => {
+  it('should return null if the JWT cookie is not set', async () => {
     ;(Cookies.get as CookiesGetByNameFn) = jest.fn(() => undefined)
-    const user = getUser()
+    const user = await getUser()
 
     expect(user).toBeNull()
   })

--- a/packages/authentication/modules/user/getUser/index.ts
+++ b/packages/authentication/modules/user/getUser/index.ts
@@ -5,10 +5,10 @@ import { IJWTContent } from '@baseapp-frontend/utils/types/jwt'
 import { IUser } from '../../../types/user'
 import { GetUserOptions } from './types'
 
-const getUser = <TUser extends Partial<IUser> & IJWTContent>({
+const getUser = async <TUser extends Partial<IUser> & IJWTContent>({
   cookieName = ACCESS_COOKIE_NAME,
 }: GetUserOptions = {}) => {
-  const token = getToken(cookieName)
+  const token = await getToken(cookieName)
   if (token) {
     try {
       const user = decodeJWT<TUser>(token)

--- a/packages/authentication/modules/user/useSimpleTokenUser/__tests__/useSimpleTokenUser.test.tsx
+++ b/packages/authentication/modules/user/useSimpleTokenUser/__tests__/useSimpleTokenUser.test.tsx
@@ -5,18 +5,38 @@ import {
   renderHook,
   waitFor,
 } from '@baseapp-frontend/test'
-import { axios } from '@baseapp-frontend/utils'
 
+import { UseQueryResult } from '@tanstack/react-query'
 import Cookies from 'js-cookie'
 
 import { IUser } from '../../../../types/user'
-import useSimpleTokenUser from '../index'
+import { IUseSimpleTokenUser } from '../types'
 import request from './fixtures/request.json'
 
-// @ts-ignore TODO: (BA-1081) investigate AxiosRequestHeaders error
-export const axiosMock = new MockAdapter(axios)
+interface IUseSimpleTokenUserResult<IUser> extends Omit<UseQueryResult<IUser, unknown>, 'data'> {
+  user?: IUser
+}
 
 describe('useSimpleTokenUser', () => {
+  let useSimpleTokenUser: <TUser extends Partial<IUser>>(
+    props?: IUseSimpleTokenUser<TUser>,
+  ) => IUseSimpleTokenUserResult<TUser>
+  let defaultTokenType: string | undefined
+  let axios: any
+  let axiosMock: MockAdapter
+
+  beforeAll(async () => {
+    defaultTokenType = process.env.NEXT_PUBLIC_TOKEN_TYPE
+    process.env.NEXT_PUBLIC_TOKEN_TYPE = 'simple'
+    axios = (await import('@baseapp-frontend/utils')).axios
+    axiosMock = new MockAdapter(axios)
+    useSimpleTokenUser = (await import('../index')).default as any
+  })
+
+  afterAll(() => {
+    process.env.NEXT_PUBLIC_TOKEN_TYPE = defaultTokenType
+  })
+
   test('should user be present for authenticated', async () => {
     ;(Cookies.get as CookiesGetByNameFn) = jest.fn(() => 'fake token')
 
@@ -80,4 +100,6 @@ describe('useSimpleTokenUser', () => {
     await waitFor(() => expect(Cookies.remove).toHaveBeenCalled())
     expect(result.current.user).not.toBeDefined()
   })
+
+  process.env.NEXT_PUBLIC_TOKEN_TYPE = defaultTokenType
 })

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/authentication",
   "description": "Authentication modules.",
-  "version": "1.2.6",
+  "version": "2.0.0",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,11 +1,19 @@
 # @baseapp-frontend/utils
 
+## 2.0.0
+
+### Major Changes
+
+- The axios instance will try to refresh the access token on the request interceptor if the JWT token flow is used, enabling the flow to be used with file uploads.
+- The getToken function is async now, handle accordingly.
+- The refreshAccessToken function was moved to its own file and it won't try to make the request again on a 401 error.
+- Some 'use client' directives were added to allow imports on server-side components.
+
 ## 1.4.4
 
 ### Patch Changes
 
 - Make `OptionalActions` types inside `withController` more flexible.
-
 
 ## 1.4.3
 

--- a/packages/utils/functions/axios/createAxiosInstance/__tests__/createAxiosInstance.test.ts
+++ b/packages/utils/functions/axios/createAxiosInstance/__tests__/createAxiosInstance.test.ts
@@ -17,6 +17,12 @@ jest.mock('js-cookie', () => ({
   ...jest.requireActual('js-cookie'),
   get: () => 'someAuthToken',
 }))
+jest.mock('../../../token/decodeJWT', () => ({
+  decodeJWT: () => ({ exp: 1234567890 }),
+}))
+jest.mock('../../../token/isUserTokenValid', () => ({
+  isUserTokenValid: () => true,
+}))
 
 describe('createAxiosInstance', () => {
   afterEach(() => {

--- a/packages/utils/functions/form/withController/index.tsx
+++ b/packages/utils/functions/form/withController/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { ChangeEventHandler, FC, FocusEventHandler } from 'react'
 
 import { Controller } from 'react-hook-form'

--- a/packages/utils/functions/token/decodeJWT/index.ts
+++ b/packages/utils/functions/token/decodeJWT/index.ts
@@ -1,5 +1,11 @@
 import humps from 'humps'
 import jwt_decode from 'jwt-decode'
 
-export const decodeJWT = <JWTContentType>(token: string) =>
-  humps.camelizeKeys(jwt_decode(token)) as JWTContentType
+export const decodeJWT = <JWTContentType>(token: string) => {
+  try {
+    return humps.camelizeKeys(jwt_decode(token)) as JWTContentType
+  } catch (error) {
+    // If the token has an invalid format, jwt_decode throws an error
+    return null
+  }
+}

--- a/packages/utils/functions/token/getToken/__tests__/getClientSideToken.test.ts
+++ b/packages/utils/functions/token/getToken/__tests__/getClientSideToken.test.ts
@@ -20,10 +20,10 @@ describe('getToken function on the client', () => {
     jest.clearAllMocks()
   })
 
-  it('retrieves a client-side cookie', () => {
+  it('retrieves a client-side cookie', async () => {
     ;(ClientCookies.get as CookiesGetByNameFn) = jest.fn(() => clientCookieValue)
 
-    expect(getToken(cookieName)).toBe(clientCookieValue)
+    expect(await getToken(cookieName)).toBe(clientCookieValue)
     expect(ClientCookies.get).toHaveBeenCalledWith(cookieName)
   })
 })

--- a/packages/utils/functions/token/getToken/__tests__/getServerSideToken.test.ts
+++ b/packages/utils/functions/token/getToken/__tests__/getServerSideToken.test.ts
@@ -23,9 +23,9 @@ describe('getToken function on the server', () => {
     jest.clearAllMocks()
   })
 
-  it('retrieves a server-side cookie', () => {
+  it('retrieves a server-side cookie', async () => {
     ;(ClientCookies.get as CookiesGetByNameFn) = jest.fn(() => clientCookieValue)
 
-    expect(getToken(cookieName)).toBe(serverCookieValue)
+    expect(await getToken(cookieName)).toBe(serverCookieValue)
   })
 })

--- a/packages/utils/functions/token/getToken/index.ts
+++ b/packages/utils/functions/token/getToken/index.ts
@@ -1,10 +1,10 @@
 import ClientCookies from 'js-cookie'
-import { cookies as serverCookies } from 'next/headers'
 
 import { ACCESS_COOKIE_NAME } from '../../../constants/cookie'
 
-export const getToken = (cookieName = ACCESS_COOKIE_NAME) => {
+export const getToken = async (cookieName = ACCESS_COOKIE_NAME) => {
   if (typeof window === typeof undefined) {
+    const { cookies: serverCookies } = await import('next/headers')
     return serverCookies().get(cookieName)?.value
   }
   return ClientCookies.get(cookieName)

--- a/packages/utils/functions/token/index.ts
+++ b/packages/utils/functions/token/index.ts
@@ -1,3 +1,4 @@
 export * from './decodeJWT'
 export * from './getToken'
 export * from './isUserTokenValid'
+export * from './refreshAccessToken'

--- a/packages/utils/functions/token/refreshAccessToken/index.ts
+++ b/packages/utils/functions/token/refreshAccessToken/index.ts
@@ -1,0 +1,38 @@
+import _axios from 'axios'
+import Cookies from 'js-cookie'
+
+import { IJWTResponse } from '../../../types/jwt'
+
+const REFRESH_TOKEN_URL = '/auth/refresh'
+
+// We create an isolated axios instance to skip the interceptors
+export const simpleAxios = _axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+})
+
+export const refreshAccessToken = async (cookieName: string, refreshCookieName: string) => {
+  const refreshToken = Cookies.get(refreshCookieName)
+
+  if (!refreshToken) {
+    return Promise.reject(new Error('No refresh token'))
+  }
+
+  try {
+    const responseData = (
+      await simpleAxios.post(REFRESH_TOKEN_URL, {
+        refresh: refreshToken,
+      })
+    ).data as IJWTResponse
+
+    Cookies.set(cookieName, responseData.access, {
+      secure: process.env.NODE_ENV === 'production',
+    })
+
+    return responseData.access
+  } catch (error) {
+    Cookies.remove(cookieName)
+    Cookies.remove(refreshCookieName)
+
+    return Promise.reject(error)
+  }
+}

--- a/packages/utils/hooks/useDebounce/index.ts
+++ b/packages/utils/hooks/useDebounce/index.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useEffect, useRef } from 'react'
 
 import debounce from 'lodash/debounce'

--- a/packages/utils/hooks/useDjangoOrderBy/index.ts
+++ b/packages/utils/hooks/useDjangoOrderBy/index.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useState } from 'react'
 
 import { decamelize } from 'humps'

--- a/packages/utils/hooks/useEventSubscription/index.ts
+++ b/packages/utils/hooks/useEventSubscription/index.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useEffect } from 'react'
 
 import { eventEmitter } from '../../functions/events'

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/utils",
   "description": "Util functions, constants and types.",
-  "version": "1.4.4",
+  "version": "2.0.0",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {


### PR DESCRIPTION
We don't handle the JWT refresh token flow with the axios instance meant for file uploads. This PR fixes that. We are changing the flow slightly to call the refresh endpoint before each request if we found out that the access token is expired because the formData gets consumed in the request and I couldn't find a nice way to keep a copy of it for the second request. This ends up having a little better performance since we make only 2 requests now, instead of 3, if the token expired. HOWEVER, there's this tiny tiny chance that the token expires in the middle of reaching the BE. If someone is concerned with that we can add a threshold in the token verification function to always refresh the token a little bit before it expires.