### PR TITLE
Add multi-param support to useDebounce, add useDebouncedValue

### DIFF
--- a/packages/utils/hooks/useDebounce/index.ts
+++ b/packages/utils/hooks/useDebounce/index.ts
@@ -1,11 +1,11 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 import debounce from 'lodash/debounce'
 
-const useDebounce = <T extends (params: any) => any>(
-  functionToDebounce: T,
+const useDebounce = <T extends any[], U>(
+  functionToDebounce: (...params: T) => U,
   { debounceTime = 400 } = {},
 ) => {
   const debouncedFuncRef = useRef(debounce(functionToDebounce, debounceTime, { trailing: true }))
@@ -20,4 +20,21 @@ const useDebounce = <T extends (params: any) => any>(
   return { debouncedFunction: debouncedFuncRef.current }
 }
 
-export default useDebounce
+const useDebouncedValue = <T>(value: T, debounceTime: number) => {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value)
+    }, debounceTime)
+
+    return () => {
+      clearTimeout(handler)
+    }
+  }, [value, debounceTime])
+
+  return debouncedValue
+}
+
+
+export {useDebounce as default, useDebouncedValue}


### PR DESCRIPTION
Updated the `useDebounce` to allow for more than one parameter. 

useDebouncedValue lets you debounce a value instead of function, something like
```
const [searchValue, setSearchValue] = useState("")
const debouncedSearchValue = useDebouncedValue(searchValue, 150)
```
this lets the UI update immidietly be tracking `searchValue` but the `debouncedSearchValue` only updated after 150ms (and only once per 150ms period)

@deboracosilveira I believe you originally wrote the `useDebouncedValue` for WAYS :smile: 