### PR TITLE
BA: exclude app templates from relay

### DIFF
--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/config
 
+## 2.1.3
+
+### Patch Changes
+
+- Exclude `./app-templates` folder from the relay compiler.
+
 ## 2.1.2
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/config",
   "description": "Reusable configurations for eslint, prettier, jest and relay",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "main": "index.js",
   "files": [
     ".eslintrc.js",

--- a/packages/config/relay.config.ts
+++ b/packages/config/relay.config.ts
@@ -1,7 +1,7 @@
 module.exports = {
   src: './',
   schema: './schema.graphql',
-  exclude: ['**/.next/**', '**/node_modules/**', '**/__generated__/**'],
+  exclude: ['**/.next/**', '**/node_modules/**', '**/__generated__/**', '**/.app-templates/**'],
   language: 'typescript',
   artifactDirectory: './__generated__',
 }


### PR DESCRIPTION
* `config` package update - `v 2.1.3`
  - Exclude `./app-templates` folder from the relay compiler.
