### PR TITLE
BA: export service auth variables

### DIFF
--- a/packages/authentication/CHANGELOG.md
+++ b/packages/authentication/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/authentication
 
+## 2.1.1
+
+### Patch Changes
+
+- Export variables from `services/auth`
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/authentication/index.ts
+++ b/packages/authentication/index.ts
@@ -3,8 +3,11 @@ export * from './modules/mfa'
 export * from './modules/user'
 
 export { default as AuthApi } from './services/auth'
+export * from './services/auth'
+
 export { default as MfaApi } from './services/mfa'
 export * from './services/mfa'
+
 export { default as UserApi } from './services/user'
 export * from './services/user'
 

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/authentication",
   "description": "Authentication modules.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {

--- a/packages/design-system-mui/CHANGELOG.md
+++ b/packages/design-system-mui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/design-system-mui
 
+## 1.5.1
+
+### Patch Changes
+
+- Ignore TS errors, probably caused by the `compilerOptions` update made by the `tsconfig v1.1.5` update.
+
 ## 1.5.0
 
 ### Minor Changes

--- a/packages/design-system-mui/components/CheckboxField/index.tsx
+++ b/packages/design-system-mui/components/CheckboxField/index.tsx
@@ -27,6 +27,7 @@ const CheckboxField = <TForm extends FieldValues>({
   FormControlProps,
 }: ICheckboxFieldProps<TForm>) => {
   const formError = form?.formState?.errors?.[name]?.message
+  // @ts-ignore TODO: (BA-1081) investigate react-hook-form types
   const innerShowError = (formError && form?.formState?.touchedFields?.[name]) as boolean
 
   return (

--- a/packages/design-system-mui/package.json
+++ b/packages/design-system-mui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/design-system-mui",
   "description": "Design System components and configurations.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {


### PR DESCRIPTION
* `authentication` package update - `v 2.1.1`
  - Export variables from `services/auth`

* `design-system-mui` package update - `v 1.5.1`
  - Ignore TS errors, probably caused by the `compilerOptions` update made by the `tsconfig v1.1.5` update.
