### PR TITLE
BA: Fix type issue on BaseAppFetchOptions

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/utils
 
+## 2.2.1
+
+### Patch Changes
+
+- Fix type issue on `BaseAppFetchOptions`.
+
 ## 2.2.0
 
 ### Minor Changes

--- a/packages/utils/functions/fetch/baseAppFetch/types.ts
+++ b/packages/utils/functions/fetch/baseAppFetch/types.ts
@@ -36,4 +36,4 @@ export interface RequestOptions extends Omit<RequestInit, 'body' | 'headers'> {
   headers?: RequestInit['headers'] & ExtraHeaders
 }
 
-export interface BaseAppFetchOptions extends RequestOptions, NextFetchOptions, Config {}
+export type BaseAppFetchOptions = RequestOptions & NextFetchOptions & Config

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/utils",
   "description": "Util functions, constants and types.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {


### PR DESCRIPTION
* `utils` package update - `v 2.2.1`
  - Fix type issue on `BaseAppFetchOptions`.
