### PR TITLE
BA-1533: Added useLogoOverrides hook and Dropzone component to Design…

### DIFF
--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @baseapp-frontend/design-system
 
+## 0.0.6
+
+### Patch Changes
+
+- Added useLogoOverrides hook and Dropzone component to Design System
+  Added getImageString to Utils pkg
+- Updated dependencies
+  - @baseapp-frontend/utils@2.5.5
+
 ## 0.0.5
 
 ### Patch Changes

--- a/packages/design-system/components/Dropzone/index.tsx
+++ b/packages/design-system/components/Dropzone/index.tsx
@@ -1,0 +1,98 @@
+import { FC, useState } from 'react'
+
+import { toBase64 } from '@baseapp-frontend/utils'
+
+import { Box, Button, Card, Typography } from '@mui/material'
+import { useDropzone } from 'react-dropzone'
+
+import {
+  ButtonContainer,
+  CancelIcon,
+  DropzoneText,
+  InputContainer,
+  PortraitOutlinedIcon,
+} from './styled'
+import { DropzoneProps } from './types'
+
+const Dropzone: FC<DropzoneProps> = ({ accept, size, storedImg, onSelect, onRemove }) => {
+  const [files, setFiles] = useState<string | undefined>(storedImg)
+  const getImageString = async (avatar: string | File | Blob) => {
+    if (typeof avatar === 'string') return avatar.length === 0 ? avatar : undefined
+    return toBase64(avatar)
+  }
+  const { open, getRootProps, getInputProps, isFocused, isDragAccept, isDragReject } = useDropzone({
+    accept,
+    onDrop: async (acceptedFiles) => {
+      if (acceptedFiles.length === 0) return
+      const imgString = await getImageString(acceptedFiles[0])
+      if (!imgString) return
+      setFiles(imgString)
+      onSelect(imgString, size)
+    },
+  })
+
+  const handleRemove = () => {
+    setFiles(undefined)
+    onRemove(size)
+  }
+
+  const Input = (
+    <div style={{ width: '100%' }} className="container">
+      <InputContainer {...getRootProps({ isFocused, isDragAccept, isDragReject })}>
+        <input {...getInputProps()} />
+        {isDragReject ? (
+          <>
+            <CancelIcon />
+            <DropzoneText hasError>File not accepted, please choose the correct type</DropzoneText>
+            <Typography variant="caption" color="text.secondary">
+              Max. File Size: 15MB
+            </Typography>
+          </>
+        ) : (
+          <>
+            <PortraitOutlinedIcon />
+            <DropzoneText>
+              <DropzoneText color="primary">Click to browse</DropzoneText> or drag and drop.
+            </DropzoneText>
+            <Typography variant="caption" color="text.secondary">
+              Max. File Size: 15MB
+            </Typography>
+          </>
+        )}
+      </InputContainer>
+    </div>
+  )
+
+  const Preview = (
+    <Card>
+      {files && (
+        <Box mt={2} display="flex" flexDirection="column" alignItems="center">
+          <img
+            key={files}
+            src={files}
+            alt="preview"
+            style={{ maxHeight: '200px', maxWidth: '100%' }}
+          />
+        </Box>
+      )}
+    </Card>
+  )
+
+  return (
+    <div className="grid grid-rows-[1fr_min-content] gap-4">
+      {files ? Preview : Input}
+      <ButtonContainer>
+        <Button variant="outlined" color="inherit" onClick={open} disableRipple type="button">
+          Upload File
+        </Button>
+        {files && (
+          <Button variant="text" color="error" onClick={handleRemove}>
+            Remove
+          </Button>
+        )}
+      </ButtonContainer>
+    </div>
+  )
+}
+
+export default Dropzone

--- a/packages/design-system/components/Dropzone/styled.tsx
+++ b/packages/design-system/components/Dropzone/styled.tsx
@@ -1,0 +1,67 @@
+import { CancelOutlined, PortraitOutlined } from '@mui/icons-material'
+import { Box, Typography } from '@mui/material'
+import { alpha, styled } from '@mui/material/styles'
+
+import { DropzoneTextProps, InputContainerProps } from './types'
+
+const getColor = ({ theme, isDragAccept, isDragReject, isFocused }: InputContainerProps) => {
+  if (isDragAccept) {
+    return theme?.palette.success.main
+  }
+  if (isDragReject) {
+    return theme?.palette.error.main
+  }
+  if (isFocused) {
+    return theme?.palette.info.main
+  }
+  return theme?.palette.grey[300]
+}
+
+export const PortraitOutlinedIcon = styled(PortraitOutlined)(({ theme }) => ({
+  color: theme.palette.grey[600],
+}))
+
+export const CancelIcon = styled(CancelOutlined)(({ theme }) => ({
+  color: theme.palette.error.main,
+}))
+
+export const DropzoneText = styled(Typography, {
+  shouldForwardProp: (props) => props !== 'hasError',
+})<DropzoneTextProps>(({ theme, hasError }) => ({
+  ...theme.typography.body2,
+  fontFamily: theme.typography.fontFamily,
+  color: hasError ? theme.palette.error.main : theme.palette.text.primary,
+  fontWeight: 400,
+  width: '100%',
+  textAlign: 'center',
+}))
+
+export const InputContainer = styled('div', {
+  shouldForwardProp: (prop) =>
+    prop !== 'isDragAccept' && prop !== 'isDragReject' && prop !== 'isFocused',
+})<InputContainerProps>(({ theme, isDragAccept, isDragReject, isFocused }) => ({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: 20,
+  borderWidth: 1,
+  borderRadius: 5,
+  borderColor: getColor({ theme, isDragAccept, isDragReject, isFocused }),
+  borderStyle: 'dashed',
+  backgroundColor: alpha(theme.palette.primary.main, 0.08),
+  color: '#bdbdbd',
+  outline: 'none',
+  transition: 'border .24s ease-in-out',
+  '&:hover': {
+    cursor: 'pointer',
+  },
+}))
+
+export const ButtonContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  justifySelf: 'center',
+  width: 'fit-content',
+  gap: theme.spacing(2),
+}))

--- a/packages/design-system/components/Dropzone/types.ts
+++ b/packages/design-system/components/Dropzone/types.ts
@@ -1,0 +1,24 @@
+import { TypographyProps } from '@mui/material'
+import { Theme } from '@mui/material/styles'
+import { Accept } from 'react-dropzone'
+
+import { LogoOverrides } from '../../hooks/useLogoOverrides/types'
+
+export interface InputContainerProps {
+  theme?: Theme
+  isDragAccept: boolean
+  isDragReject: boolean
+  isFocused: boolean
+}
+
+export interface DropzoneTextProps extends TypographyProps {
+  hasError?: boolean
+}
+
+export interface DropzoneProps {
+  accept: Accept
+  size: keyof LogoOverrides
+  storedImg?: string
+  onSelect: (imgString: string, size: keyof LogoOverrides) => void
+  onRemove: (size: keyof LogoOverrides) => void
+}

--- a/packages/design-system/hooks/useLogoOverrides/constants.ts
+++ b/packages/design-system/hooks/useLogoOverrides/constants.ts
@@ -1,0 +1,8 @@
+import { LogoOverrides } from './types'
+
+export const DEFAULT_LOGO_KEY = 'logo-overrides'
+
+export const DEFAULT_LOGO_SETTINGS: LogoOverrides = {
+  default: undefined,
+  square: undefined,
+}

--- a/packages/design-system/hooks/useLogoOverrides/index.ts
+++ b/packages/design-system/hooks/useLogoOverrides/index.ts
@@ -1,0 +1,49 @@
+'use client'
+
+import { ServerSideRenderingOption, getCookie, setCookie } from '@baseapp-frontend/utils'
+
+import { atom, useAtom } from 'jotai'
+
+import { DEFAULT_LOGO_KEY, DEFAULT_LOGO_SETTINGS } from './constants'
+import { LogoOverrides } from './types'
+
+export const getLogoOverridesFromCookie = ({ noSSR = true }: ServerSideRenderingOption = {}) => {
+  const settings = getCookie<LogoOverrides>(DEFAULT_LOGO_KEY, { noSSR }) ?? DEFAULT_LOGO_SETTINGS
+
+  return settings
+}
+
+const initialLogos = getLogoOverridesFromCookie()
+
+const settingsAtom = atom<LogoOverrides>(initialLogos)
+
+/**
+ * By using `useLogoOverrides` with the `noSSR` option set to `false`, causes Next.js to dynamically render the affected pages, instead of statically rendering them.
+ */
+const useLogoOverrides = ({ noSSR = true }: ServerSideRenderingOption = {}) => {
+  const [settings, setSettings] = useAtom(settingsAtom)
+  const isSSR = typeof window === typeof undefined
+
+  const handleSetLogoOverrides = (newLogos: Partial<LogoOverrides>) => {
+    setSettings((prevLogos: LogoOverrides) => {
+      const updatedLogoOverrides = { ...prevLogos, ...newLogos }
+      setCookie(DEFAULT_LOGO_KEY, updatedLogoOverrides)
+
+      return updatedLogoOverrides
+    })
+  }
+
+  if (isSSR) {
+    return {
+      settings: getLogoOverridesFromCookie({ noSSR }),
+      setSettings: handleSetLogoOverrides,
+    }
+  }
+
+  return {
+    settings,
+    setSettings: handleSetLogoOverrides,
+  }
+}
+
+export default useLogoOverrides

--- a/packages/design-system/hooks/useLogoOverrides/types.ts
+++ b/packages/design-system/hooks/useLogoOverrides/types.ts
@@ -1,0 +1,14 @@
+export type LogoOverrides = {
+  default?: string
+  square?: string
+}
+
+export type LogoOverrideState = {
+  settings: LogoOverrides
+}
+
+type LogoOverrideFunctions = {
+  setLogoOverride: (newLogos: Partial<LogoOverrides>) => void
+}
+
+export type UseLogoOverrides = LogoOverrideState & LogoOverrideFunctions

--- a/packages/design-system/index.ts
+++ b/packages/design-system/index.ts
@@ -40,6 +40,9 @@ export type * from './components/Logo/types'
 export { default as Popover } from './components/Popover'
 export type * from './components/Popover/types'
 
+export { default as Dropzone } from './components/Dropzone'
+export type * from './components/Dropzone/types'
+
 // providers
 export { default as MotionLazyProvider } from './providers/MotionLazyProvider'
 
@@ -52,6 +55,7 @@ export type { ThemeProviderProps } from './providers/ThemeProvider/types'
 // hooks
 export * from './hooks/useResponsive'
 export * from './hooks/usePopover'
+export * from './hooks/useLogoOverrides'
 
 // types
 export type * from './types'

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/design-system",
   "description": "Design System components and configurations.",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {
@@ -27,7 +27,9 @@
     "next": "14.3.0-canary.24",
     "react-hook-form": "^7.51.5",
     "react-lazy-load-image-component": "^1.6.2",
-    "simplebar-react": "^3.2.5"
+    "simplebar-react": "^3.2.5",
+    "react-dropzone": "^14.2.3",
+    "jotai": "^2.9.3"
   },
   "peerDependencies": {
     "@baseapp-frontend/utils": "*",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/utils
 
+## 2.5.5
+
+### Patch Changes
+
+- Added useLogoOverrides hook and Dropzone component to Design System
+  Added getImageString to Utils pkg
+
 ## 2.5.4
 
 ### Patch Changes

--- a/packages/utils/functions/file/getImageString/index.ts
+++ b/packages/utils/functions/file/getImageString/index.ts
@@ -1,0 +1,6 @@
+import { toBase64 } from '../toBase64'
+
+export const getImageString = async (avatar: string | File | Blob) => {
+  if (typeof avatar === 'string') return avatar.length === 0 ? avatar : undefined
+  return toBase64(avatar)
+}

--- a/packages/utils/functions/file/index.ts
+++ b/packages/utils/functions/file/index.ts
@@ -1,1 +1,2 @@
 export * from './toBase64'
+export * from './getImageString'

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/utils",
   "description": "Util functions, constants and types.",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5649,6 +5649,11 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
+attr-accept@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
+  integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
+
 autoprefixer@^10.4.19:
   version "10.4.20"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.20.tgz#5caec14d43976ef42e32dcb4bd62878e96be5b3b"
@@ -8239,6 +8244,13 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+file-selector@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.6.0.tgz#fa0a8d9007b829504db4d07dd4de0310b65287dc"
+  integrity sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==
+  dependencies:
+    tslib "^2.4.0"
+
 filelist@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.4.tgz#f78978a1e944775ff9e62e744424f215e58352b5"
@@ -10611,6 +10623,11 @@ jiti@^1.20.0, jiti@^1.21.0:
   version "1.21.6"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.6.tgz#6c7f7398dd4b3142767f9a168af2f317a428d268"
   integrity sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==
+
+jotai@^2.9.3:
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.9.3.tgz#abcae49a737cd50e3144a6c9eb39840db077c727"
+  integrity sha512-IqMWKoXuEzWSShjd9UhalNsRGbdju5G2FrqNLQJT+Ih6p41VNYe2sav5hnwQx4HJr25jq9wRqvGSWGviGG6Gjw==
 
 js-cookie@^3.0.5:
   version "3.0.5"
@@ -13158,6 +13175,15 @@ react-docgen@^7.0.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
+
+react-dropzone@^14.2.3:
+  version "14.2.3"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-14.2.3.tgz#0acab68308fda2d54d1273a1e626264e13d4e84b"
+  integrity sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==
+  dependencies:
+    attr-accept "^2.2.2"
+    file-selector "^0.6.0"
+    prop-types "^15.8.1"
 
 react-element-to-jsx-string@^15.0.0:
   version "15.0.0"


### PR DESCRIPTION
… System, Added getImageString to Utils pkg

Acceptance Criteria 
Context
This user story focuses on making it easy to change the BaseApp logo to a prospect client's logo for quick demos.

Given the need to change logos on demand.
When the feature is implemented.
Then it should support the following functionalities:

Dynamic Logo Display:

create/use the Theme section inside the user's settings page and build the Logo section there

create image inputs for normal logo and condensed logos

the inputs show the current logo as the preview image

it should accept only SVG formats

after the image upload and saving, we should convert the SVG to base64 and store it in the local storage

ensure all static logo images use the local storage base64 image as the first option; if it's not found, use the static image

the logo change is meant to be temporary, meaning that if the person didn't upload any image, the app shall render the static image instead

the change should be only applicable to the user session (e.g., someone accessing the site from a different computer should not be able to detect the logo change)

only superusers will have permissions to change any logo image 

Design Link: https://www.figma.com/design/XRD6wSl1m8Kz6XUcAy5CLp/BaseApp-Minimal-v5.4.0?node-id=2085-40113&t=zxCMuRHZ1Rp3OOt5-0 

Approvd 
https://app.approvd.io/silverlogic/BA/stories/31638 
