### PR TITLE
BA-1548: changed useLogoOverrides to use localStorage...

### DIFF
--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/design-system
 
+## 0.0.8
+
+### Patch Changes
+
+- Changed useLogoOverrides to use localStorage instead of cookies, moved project logo to design-system
+
 ## 0.0.7
 
 ### Patch Changes

--- a/packages/design-system/components/CustomLogoCondensed/index.tsx
+++ b/packages/design-system/components/CustomLogoCondensed/index.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { FC } from 'react'
+
+import Image from 'next/image'
+
+import useLogoOverrides from '../../hooks/useLogoOverrides'
+
+const CustomLogoCondensed: FC = () => {
+  const { logos } = useLogoOverrides()
+  if (!logos?.square) {
+    return null
+  }
+  return (
+    <Image
+      key={logos.square}
+      src={logos.square}
+      alt="Custom Project Logo Condensed"
+      height={34}
+      width={38}
+    />
+  )
+}
+
+export default CustomLogoCondensed

--- a/packages/design-system/components/Dropzone/index.tsx
+++ b/packages/design-system/components/Dropzone/index.tsx
@@ -66,7 +66,7 @@ const Dropzone: FC<DropzoneProps> = ({ accept, size, storedImg, onSelect, onRemo
   const Preview = (
     <Card>
       {files && (
-        <Box mt={2} display="flex" flexDirection="column" alignItems="center">
+        <Box p={2} display="flex" flexDirection="column" alignItems="center">
           <img
             key={files}
             src={files}

--- a/packages/design-system/components/ProjectLogo/index.tsx
+++ b/packages/design-system/components/ProjectLogo/index.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { FC } from 'react'
+
+import { useSSR } from '@baseapp-frontend/utils'
+
+import Image from 'next/image'
+
+import useLogoOverrides from '../../hooks/useLogoOverrides'
+import { ProjectLogoProps } from './types'
+
+const ProjectLogo: FC<ProjectLogoProps> = ({ src, alt, width, height, priority, className }) => {
+  const { logos } = useLogoOverrides()
+  const { isSSR } = useSSR()
+
+  return (
+    <Image
+      src={!isSSR && logos?.default ? logos.default : src}
+      alt={alt}
+      width={width}
+      height={height}
+      priority={priority}
+      className={className}
+    />
+  )
+}
+
+export default ProjectLogo

--- a/packages/design-system/components/ProjectLogo/types.ts
+++ b/packages/design-system/components/ProjectLogo/types.ts
@@ -1,0 +1,8 @@
+export interface ProjectLogoProps {
+  src: string
+  alt: string
+  width?: number
+  height?: number
+  priority?: boolean
+  className?: string
+}

--- a/packages/design-system/index.ts
+++ b/packages/design-system/index.ts
@@ -34,6 +34,11 @@ export type * from './components/Iconify/types'
 export { default as Scrollbar } from './components/Scrollbar'
 export type * from './components/Scrollbar/types'
 
+export { default as ProjectLogo } from './components/ProjectLogo'
+export type * from './components/ProjectLogo/types'
+
+export { default as CustomLogoCondensed } from './components/CustomLogoCondensed'
+
 export { default as Logo } from './components/Logo'
 export type * from './components/Logo/types'
 
@@ -53,9 +58,9 @@ export { default as ThemeProvider } from './providers/ThemeProvider'
 export type { ThemeProviderProps } from './providers/ThemeProvider/types'
 
 // hooks
+export * from './hooks/useLogoOverrides'
 export * from './hooks/useResponsive'
 export * from './hooks/usePopover'
-export * from './hooks/useLogoOverrides'
 
 // types
 export type * from './types'

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/design-system",
   "description": "Design System components and configurations.",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {


### PR DESCRIPTION
…instead of cookies, moved project logo to design-system.

- Previously useLogoOverrides was implemented using cookies but that has a size limit of 4kb, if a large SVG image was uploaded by the user then it would not persist upon navigating to another page. The logic was changed so that it uses localStorage to persist larger images.

- Created ProjectLogo component to completed task left by @anicioalexandre on [BA-1415: Change Logos on Demand
](https://bitbucket.org/silverlogic/baseapp-frontend-template/pull-requests/80/overview)
> create a Logo component under components/design-system and move the logic there. We should also replace the logo usage throughout the app (we use the BA default and condensed logos in many places (header, login, sigin up, forgot password….)