### PR TITLE
useForm accept options

### DIFF
--- a/packages/authentication/CHANGELOG.md
+++ b/packages/authentication/CHANGELOG.md
@@ -1,10 +1,17 @@
 # @baseapp-frontend/authentication
 
+## 3.2.5
+
+### Patch Changes
+
+- Replaced useLogin parameters `validationSchema` and `defaultValues` by unique object `loginFormOptions`
+- Replaced useSignUp parameters `validationSchema` and `defaultValues` by unique object `formOptions`
+
 ## 3.2.4
 
 ### Patch Changes
 
-- Replaced `firstName` and `lastName` with `name` in `ReigtserRequest` interface
+- Replaced `firstName` and `lastName` with `name` in `RegisterRequest,` interface
 - Replaced `firstName` and `lastName` with `name` in `useSignUp` validation schema and form default values
 
 ## 3.2.3

--- a/packages/authentication/modules/access/useLogin/__tests__/useLogin.test.tsx
+++ b/packages/authentication/modules/access/useLogin/__tests__/useLogin.test.tsx
@@ -6,6 +6,7 @@ import {
 } from '@baseapp-frontend/test'
 import { axios } from '@baseapp-frontend/utils'
 
+import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 
 import useLogin from '../index'
@@ -28,9 +29,11 @@ describe('useLogin', () => {
     const { result } = renderHook(
       () =>
         useLogin({
-          defaultValues: {
-            email,
-            password,
+          loginFormOptions: {
+            defaultValues: {
+              email,
+              password,
+            },
           },
           loginOptions: {
             onSuccess: () => {
@@ -66,8 +69,10 @@ describe('useLogin', () => {
     const { result } = renderHook(
       () =>
         useLogin({
-          defaultValues: customDefaultValues,
-          validationSchema: customValidationSchema,
+          loginFormOptions: {
+            defaultValues: customDefaultValues,
+            resolver: zodResolver(customValidationSchema),
+          },
           loginOptions: {
             onSuccess: () => {
               hasOnSuccessRan = true

--- a/packages/authentication/modules/access/useLogin/__tests__/useSimpleTokenLogin.test.tsx
+++ b/packages/authentication/modules/access/useLogin/__tests__/useSimpleTokenLogin.test.tsx
@@ -1,6 +1,7 @@
 import { ComponentWithProviders, MockAdapter, renderHook } from '@baseapp-frontend/test'
 import { TokenTypes, axios } from '@baseapp-frontend/utils'
 
+import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 
 import useLogin from '../index'
@@ -22,9 +23,11 @@ describe('useSimpleTokenLogin', () => {
     const { result } = renderHook(
       () =>
         useLogin({
-          defaultValues: {
-            email,
-            password,
+          loginFormOptions: {
+            defaultValues: {
+              email,
+              password,
+            },
           },
           loginOptions: {
             onSuccess: () => {
@@ -60,8 +63,10 @@ describe('useSimpleTokenLogin', () => {
     const { result } = renderHook(
       () =>
         useLogin({
-          defaultValues: customDefaultValues,
-          validationSchema: customValidationSchema,
+          loginFormOptions: {
+            defaultValues: customDefaultValues,
+            resolver: zodResolver(customValidationSchema),
+          },
           loginOptions: {
             onSuccess: () => {
               hasOnSuccessRan = true

--- a/packages/authentication/modules/access/useLogin/index.ts
+++ b/packages/authentication/modules/access/useLogin/index.ts
@@ -60,8 +60,7 @@ const simpleTokenSuccessHandler = (
 }
 
 const useLogin = ({
-  validationSchema = DEFAULT_VALIDATION_SCHEMA,
-  defaultValues = DEFAULT_INITIAL_VALUES,
+  loginFormOptions = {},
   loginOptions = {},
   mfaOptions = {},
   tokenType = TokenTypes.jwt,
@@ -98,9 +97,10 @@ const useLogin = ({
   }
 
   const form = useForm({
-    defaultValues,
-    resolver: zodResolver(validationSchema),
+    defaultValues: DEFAULT_INITIAL_VALUES,
+    resolver: zodResolver(DEFAULT_VALIDATION_SCHEMA),
     mode: 'onBlur',
+    ...loginFormOptions,
   })
 
   const mutation = useMutation({
@@ -150,7 +150,7 @@ const useLogin = ({
       // TODO: refactor types
       handleSubmit: form.handleSubmit(async (values) => {
         try {
-          await mutation.mutateAsync(values)
+          await mutation.mutateAsync(values as LoginRequest)
         } catch (error) {
           // mutateAsync will raise an error if there's an API error
         }

--- a/packages/authentication/modules/access/useLogin/types.ts
+++ b/packages/authentication/modules/access/useLogin/types.ts
@@ -1,7 +1,7 @@
 import { TokenTypes } from '@baseapp-frontend/utils'
 
 import { UseMutationOptions } from '@tanstack/react-query'
-import { z } from 'zod'
+import { UseFormProps } from 'react-hook-form'
 
 import AuthApi from '../../../services/auth'
 import {
@@ -14,8 +14,7 @@ import {
 type ApiClass = Pick<typeof AuthApi, 'login'>
 
 export interface UseLoginOptions extends CustomCookieNames {
-  validationSchema?: z.ZodObject<z.ZodRawShape>
-  defaultValues?: LoginRequest
+  loginFormOptions?: UseFormProps<Partial<LoginRequest>>
   loginOptions?: UseMutationOptions<LoginResponse, unknown, LoginRequest, any>
   mfaOptions?: UseMutationOptions<LoginResponse, unknown, LoginMfaRequest, any>
   tokenType?: TokenTypes

--- a/packages/authentication/modules/access/useSignUp/__tests__/useSignUp.test.tsx
+++ b/packages/authentication/modules/access/useSignUp/__tests__/useSignUp.test.tsx
@@ -1,6 +1,7 @@
 import { ComponentWithProviders, MockAdapter, renderHook, waitFor } from '@baseapp-frontend/test'
 import { axios } from '@baseapp-frontend/utils'
 
+import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 
 import { RegisterRequest } from '../../../../types/auth'
@@ -21,7 +22,9 @@ describe('useSignUp', () => {
     const { result } = renderHook(
       () =>
         useSignUp({
-          defaultValues: request,
+          formOptions: {
+            defaultValues: request,
+          },
           options: {
             onSuccess: () => {
               hasOnSuccessRan = true
@@ -53,7 +56,9 @@ describe('useSignUp', () => {
     const { result } = renderHook(
       () =>
         useSignUp<CustomRegisterRequest, CustomRegisterResponse>({
-          defaultValues: customRequest,
+          formOptions: {
+            defaultValues: customRequest,
+          },
         }),
       {
         wrapper: ComponentWithProviders,
@@ -76,7 +81,9 @@ describe('useSignUp', () => {
     const { result } = renderHook(
       () =>
         useSignUp({
-          defaultValues: request,
+          formOptions: {
+            defaultValues: request,
+          },
           options: {
             onError: () => {
               hasOnErrorRan = true
@@ -112,8 +119,10 @@ describe('useSignUp', () => {
     const { result } = renderHook(
       () =>
         useSignUp<CustomRegisterRequest>({
-          defaultValues: customDefaultValues,
-          validationSchema: customValidationSchema,
+          formOptions: {
+            defaultValues: customDefaultValues,
+            resolver: zodResolver(customValidationSchema),
+          },
           options: {
             onSuccess: () => {
               hasOnSuccessRan = true

--- a/packages/authentication/modules/access/useSignUp/index.ts
+++ b/packages/authentication/modules/access/useSignUp/index.ts
@@ -12,17 +12,17 @@ import { DEFAULT_INITIAL_VALUES, DEFAULT_VALIDATION_SCHEMA } from './constants'
 import { UseSignUpOptions } from './types'
 
 const useSignUp = <TRegisterRequest extends RegisterRequest, TRegisterResponse = void>({
-  validationSchema = DEFAULT_VALIDATION_SCHEMA,
-  defaultValues = DEFAULT_INITIAL_VALUES as TRegisterRequest,
+  formOptions = {},
   ApiClass = AuthApi,
   enableFormApiErrors = true,
   options = {},
 }: UseSignUpOptions<TRegisterRequest, TRegisterResponse> = {}) => {
   const form = useForm({
     // @ts-ignore TODO: DeepPartial type error will be fixed on v8
-    defaultValues,
-    resolver: zodResolver(validationSchema),
+    defaultValues: DEFAULT_INITIAL_VALUES,
+    resolver: zodResolver(DEFAULT_VALIDATION_SCHEMA),
     mode: 'onBlur',
+    ...formOptions,
   })
 
   const mutation = useMutation({
@@ -51,7 +51,7 @@ const useSignUp = <TRegisterRequest extends RegisterRequest, TRegisterResponse =
     form: {
       ...form,
       // TODO: improve types
-      handleSubmit: form.handleSubmit(handleSubmit) as any,
+      handleSubmit: form.handleSubmit(handleSubmit as () => void) as any,
     },
     mutation,
   }

--- a/packages/authentication/modules/access/useSignUp/types.ts
+++ b/packages/authentication/modules/access/useSignUp/types.ts
@@ -1,5 +1,5 @@
 import { UseMutationOptions } from '@tanstack/react-query'
-import { z } from 'zod'
+import { UseFormProps } from 'react-hook-form'
 
 import AuthApi from '../../../services/auth'
 import { RegisterRequest } from '../../../types/auth'
@@ -7,7 +7,7 @@ import { RegisterRequest } from '../../../types/auth'
 type ApiClass = Pick<typeof AuthApi, 'register'>
 
 export interface UseSignUpOptions<TRegisterRequest = RegisterRequest, TRegisterResponse = void> {
-  validationSchema?: z.ZodObject<z.ZodRawShape>
+  formOptions?: UseFormProps<Partial<TRegisterRequest>>
   defaultValues?: TRegisterRequest
   ApiClass?: ApiClass
   options?: UseMutationOptions<TRegisterResponse, unknown, TRegisterRequest, any>

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/authentication",
   "description": "Authentication modules.",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "main": "./dist/index.ts",
   "module": "./dist/index.mjs",
   "scripts": {


### PR DESCRIPTION
Instead of passing parameters `defaultValues` and `validationSchema` we now pass form options, which can leave the definition for the project and alter other parameters (e.g. `mode`)