### PR TITLE
BA-1721: Add Component Testing to the @baseapp-frontend Pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         run: pnpm lint
 
   test-unit:
-    name: Unit Test
+    name: Unit Test Applications and Packages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -78,7 +78,7 @@ jobs:
         run: pnpm test:unit
 
   test-component:
-    name: Component Test
+    name: Component Test Applications and Packages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,3 +76,26 @@ jobs:
 
       - name: Test Applications and Packages
         run: pnpm test:unit
+
+  test-component:
+    name: Component Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.17.0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test Components
+        run: pnpm test:component

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Lint Applications and Packages
         run: pnpm lint
 
-  test:
-    name: Test
+  test-unit:
+    name: Unit Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -75,4 +75,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Test Applications and Packages
-        run: pnpm test
+        run: pnpm test:unit

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "turbo run build --filter=./packages/utils",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
-    "test": "turbo run test",
+    "test:unit": "turbo run test:unit",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "turbo run build && changeset publish",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
     "test:unit": "turbo run test:unit",
+    "test:component": "turbo run test:component",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "turbo run build && changeset publish",

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "rm -rf dist && tsc --build tsconfig.build.json",
     "dev": "tsc --watch",
-    "test": "jest --config ./jest.config.ts",
+    "test:unit": "jest --config ./jest.config.ts",
     "lint": "eslint . --ext .tsx --ext .ts && tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },

--- a/packages/components/cypress.config.ts
+++ b/packages/components/cypress.config.ts
@@ -6,6 +6,7 @@ import webpackConfig from './webpack.config'
 export default defineConfig({
   component: {
     specPattern: './modules/**/__tests__/*.cy.{js,ts,jsx,tsx}',
+    defaultCommandTimeout: 10000,
     devServer({ cypressConfig, devServerEvents, specs }) {
       return startDevServer({
         webpackConfig: webpackConfig as any,

--- a/packages/components/modules/comments/Comments/__tests__/Comments.cy.tsx
+++ b/packages/components/modules/comments/Comments/__tests__/Comments.cy.tsx
@@ -98,9 +98,12 @@ describe('Comments', () => {
     cy.findByLabelText('replies count comment-2').should('have.text', '2')
 
     cy.step('Unpin a comment')
-    cy.findByText('This is a pinned comment.').click()
+    cy.findByText('This is a pinned comment.')
+      .click()
+      .wait(500) // Add small delay to ensure menu is rendered
     cy.findByText('Pinned').should('exist')
     cy.findByRole('button', { name: /unpin comment/i })
+      .should('be.visible') // Add visibility check
       .click()
       .then(() => {
         resolveMostRecentOperation({ data: unpinACommentMockData })

--- a/packages/components/modules/comments/Comments/__tests__/Comments.cy.tsx
+++ b/packages/components/modules/comments/Comments/__tests__/Comments.cy.tsx
@@ -98,12 +98,9 @@ describe('Comments', () => {
     cy.findByLabelText('replies count comment-2').should('have.text', '2')
 
     cy.step('Unpin a comment')
-    cy.findByText('This is a pinned comment.')
-      .click()
-      .wait(500) // Add small delay to ensure menu is rendered
+    cy.findByText('This is a pinned comment.').click()
     cy.findByText('Pinned').should('exist')
     cy.findByRole('button', { name: /unpin comment/i })
-      .should('be.visible') // Add visibility check
       .click()
       .then(() => {
         resolveMostRecentOperation({ data: unpinACommentMockData })

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -17,7 +17,7 @@
     "storybook:build": "storybook build",
     "cypress:clean": "rm -rf ./cypress/downloads ./cypress/screenshots ./cypress/videos",
     "cypress:open": "cypress open --browser chrome",
-    "test:component": "cypress run --component --browser chrome --headless"
+    "test:component": "cypress run --component --browser chrome --headed"
   },
   "dependencies": {
     "@hookform/resolvers": "catalog:",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -16,7 +16,8 @@
     "storybook": "storybook dev -p 6007",
     "storybook:build": "storybook build",
     "cypress:clean": "rm -rf ./cypress/downloads ./cypress/screenshots ./cypress/videos",
-    "cypress:open": "cypress open --browser chrome"
+    "cypress:open": "cypress open --browser chrome",
+    "test:component": "cypress run --component --browser chrome --headless"
   },
   "dependencies": {
     "@hookform/resolvers": "catalog:",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "rm -rf dist && tsc --build tsconfig.build.json",
     "dev": "tsc --watch",
-    "test": "jest --config ./jest.config.ts",
+    "test:unit": "jest --config ./jest.config.ts",
     "lint": "eslint . --ext .tsx --ext .ts && tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,9 @@
     "test:unit": {
       "dependsOn": ["^build"]
     },
+    "test:component": {
+      "dependsOn": ["^build"]
+    },
     "clean": {
       "cache": false
     },

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,7 @@
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
-    "test": {
+    "test:unit": {
       "dependsOn": ["^build"]
     },
     "clean": {


### PR DESCRIPTION
Acceptance Criteria 
To ensure that both unit and component tests are executed as part of the pipeline, we will be updating the current setup to accommodate component testing. This involves renaming the existing test step to reflect that it only covers unit tests and adding a new step for component tests executed by Cypress.

Rename the existing "Test" step in GitHub Actions to "Unit Test" to clarify that it is only responsible for unit tests.

Update the existing unit test script on the `@baseapp-frontend` packages (utils and authentication) from `test` to `test:unit` to reflect its specificity.

Add a new npm script `"test:component"` in the `@baseapp-frontend/components` package.  

Ensure this script runs Cypress to perform headless component testing on all tests cases available inside the package

In the main GitHub Actions Main workflow, add both the `test:unit` and `test:component` scripts to the pipeline.

Ensure that component tests are run as a separate step following the unit tests. 

Notes 

Existent component test we have under @baseapp-frontend/components: https://github.com/silverlogic/baseapp-frontend/blob/master/packages/components/modules/comments/Comments/__tests__/Comments.cy.tsx 

Approvd 
https://app.approvd.io/silverlogic/BA/stories/36005 