### PR TITLE
BA-hotfix: cookie getter and setter won't parse or stringfy as default

### DIFF
--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -7,8 +7,8 @@
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && tsc --build tsconfig.build.json",
-    "dev": "tsc --watch",
-    "test:unit": "jest --config ./jest.config.ts",
+    "dev": "rm -rf dist && tsc --watch",
+    "test:unit": "rm -rf dist && jest --config ./jest.config.ts",
     "lint": "eslint . --ext .tsx --ext .ts && tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },

--- a/packages/authentication/tsconfig.json
+++ b/packages/authentication/tsconfig.json
@@ -15,5 +15,5 @@
     "*.d.ts",
     "jest.config.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && tsc --build tsconfig.build.json",
-    "dev": "tsc --watch",
+    "dev": "rm -rf dist && tsc --watch",
     "relay": "relay-compiler",
     "relay-download-schema": "dotenv -- bash -c 'get-graphql-schema \"$NEXT_PUBLIC_RELAY_ENDPOINT\" > schema.graphql'",
     "relay-update-schema": "yarn relay-download-schema && yarn relay",

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -15,5 +15,5 @@
     ".storybook/**/*",
     ".storybook/**/*.json"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && tsc --build tsconfig.build.json",
-    "dev": "tsc --watch",
+    "dev": "rm -rf dist && tsc --watch",
     "lint": "eslint . --ext .tsx --ext .ts && tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "storybook": "storybook dev -p 6006",

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -13,5 +13,5 @@
     "index.d.ts",
     "jest.config.ts"
   ],
-  "exclude": ["node_modules", "./relay.config.js"]
+  "exclude": ["node_modules", "./relay.config.js", "dist"]
 }

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -14,5 +14,5 @@
     "*.d.ts",
     "jest.config.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && tsc --build tsconfig.build.json",
-    "dev": "tsc --watch",
+    "dev": "rm -rf dist && tsc --watch",
     "lint": "eslint . --ext .tsx --ext .ts && tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -13,5 +13,5 @@
     "index.d.ts",
     "jest.config.ts"
   ],
-  "exclude": ["node_modules", "./relay.config.js"]
+  "exclude": ["node_modules", "./relay.config.js", "dist"]
 }

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && tsc --build tsconfig.build.json",
-    "dev": "tsc --watch",
+    "dev": "rm -rf dist && tsc --watch",
     "lint": "eslint . --ext .tsx --ext .ts && tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },

--- a/packages/provider/tsconfig.json
+++ b/packages/provider/tsconfig.json
@@ -13,5 +13,5 @@
     "index.d.ts",
     "jest.config.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && tsc --build tsconfig.build.json",
-    "dev": "tsc --watch",
+    "dev": "rm -rf dist && tsc --watch",
     "lint": "eslint . --ext .tsx --ext .ts && tsc --noemit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "test": "echo test"

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -14,5 +14,5 @@
     "*.d.ts",
     "jest.config.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/utils
 
+## 3.0.2
+
+### Patch Changes
+
+- `getCookie` and `getCookieAsync` won't parse the value as default.
+- `setCookie` won't stringfy the value as default.
+
 ## 3.0.1
 
 ### Patch Changes

--- a/packages/utils/functions/cookie/__tests__/cookie.client.test.ts
+++ b/packages/utils/functions/cookie/__tests__/cookie.client.test.ts
@@ -1,6 +1,7 @@
 import ClientCookies from 'js-cookie'
 
 import { getCookie, removeCookie, setCookie } from '..'
+import { SetCookieOptions } from '../types'
 
 jest.mock('js-cookie', () => ({
   get: jest.fn(),
@@ -20,10 +21,10 @@ describe('Cookie Functions in the client side', () => {
     })
 
     it('should be able to parse the cookie if it is a JSON string', () => {
-      const mockCookie = '{"key": "value"}'
+      const mockCookie = JSON.stringify({ key: 'value' })
       ;(ClientCookies.get as jest.Mock).mockReturnValue(mockCookie)
 
-      const result = getCookie('test')
+      const result = getCookie('test', { parseJSON: true })
 
       expect(result).toEqual({ key: 'value' })
     })
@@ -50,9 +51,10 @@ describe('Cookie Functions in the client side', () => {
     it('should set a cookie', () => {
       const key = 'test'
       const value = { data: 'test-data' }
-      const config = { expires: 7 }
+      const config: SetCookieOptions = { expires: 7, stringfyValue: true }
 
       setCookie(key, value, config)
+      delete config.stringfyValue
       expect(ClientCookies.set).toHaveBeenCalledWith(key, JSON.stringify(value), config)
     })
 

--- a/packages/utils/functions/cookie/__tests__/cookie.server.test.ts
+++ b/packages/utils/functions/cookie/__tests__/cookie.server.test.ts
@@ -22,10 +22,10 @@ describe('Cookie Functions in the server side', () => {
     })
 
     it('should be able to parse the cookie if it is a JSON string', () => {
-      const mockCookie = '{"key": "value"}'
+      const mockCookie = JSON.stringify({ key: 'value' })
       cookiesGetMock.mockReturnValue({ value: mockCookie })
 
-      const result = getCookie('test')
+      const result = getCookie('test', { parseJSON: true })
 
       expect(result).toEqual({ key: 'value' })
     })

--- a/packages/utils/functions/cookie/index.ts
+++ b/packages/utils/functions/cookie/index.ts
@@ -1,7 +1,6 @@
-// @ts-ignore
-import ClientCookies, { CookieAttributes } from 'js-cookie'
+import ClientCookies from 'js-cookie'
 
-import { GetCookieOptions } from './types'
+import type { GetCookieOptions, SetCookieOptions } from './types'
 
 const parseCookie = <T>(cookie: string) => {
   try {
@@ -13,7 +12,7 @@ const parseCookie = <T>(cookie: string) => {
 
 export const getCookie = <T>(
   key: string,
-  { noSSR = false, parseJSON = true }: GetCookieOptions = {},
+  { noSSR = false, parseJSON = false }: GetCookieOptions = {},
 ) => {
   let cookie
   if (typeof window === typeof undefined && !noSSR) {
@@ -27,7 +26,7 @@ export const getCookie = <T>(
 
 export const getCookieAsync = async <T>(
   key: string,
-  { noSSR = false, parseJSON = true }: GetCookieOptions = {},
+  { noSSR = false, parseJSON = false }: GetCookieOptions = {},
 ) => {
   let cookie
   if (typeof window === typeof undefined && !noSSR) {
@@ -40,9 +39,14 @@ export const getCookieAsync = async <T>(
   return parseJSON ? parseCookie<T>(cookie as string) : (cookie as T)
 }
 
-export const setCookie = (key: string, value: any, config?: CookieAttributes) => {
+export const setCookie = (
+  key: string,
+  value: any,
+  { stringfyValue = false, ...config }: SetCookieOptions = {},
+) => {
   try {
-    ClientCookies.set(key, JSON.stringify(value), config)
+    const formattedValue = stringfyValue ? JSON.stringify(value) : value
+    ClientCookies.set(key, formattedValue, config)
   } catch (error) {
     console.error(error)
   }

--- a/packages/utils/functions/cookie/types.ts
+++ b/packages/utils/functions/cookie/types.ts
@@ -1,5 +1,11 @@
+import type { CookieAttributes } from 'js-cookie'
+
 import { ServerSideRenderingOption } from '../../types/server'
 
 export interface GetCookieOptions extends ServerSideRenderingOption {
   parseJSON?: boolean
+}
+
+export interface SetCookieOptions extends CookieAttributes {
+  stringfyValue?: boolean
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@baseapp-frontend/utils",
   "description": "Util functions, constants and types.",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && tsc --build tsconfig.build.json",
-    "dev": "tsc --watch",
-    "test:unit": "jest --config ./jest.config.ts",
+    "dev": "rm -rf dist && tsc --watch",
+    "test:unit": "rm -rf dist && jest --config ./jest.config.ts",
     "lint": "eslint . --ext .tsx --ext .ts && tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -14,5 +14,5 @@
     "index.d.ts",
     "jest.config.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,5 +27,5 @@
     }
   },
   "include": ["**/*.ts", "**/*.tsx", "**/*.d.ts", ".eslintrc.js"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
- `utils` package update - `v 3.0.2`
  - `getCookie` and `getCookieAsync` won't parse the value as default.
  - `setCookie` won't stringfy the value as default.
  
extra:
- remove the `dist` folder before running dev mode on the package's script.
- exclude the `dist` folder from the ts compilation.
