### PR TITLE
BA-1776 [FE] restrict upload to <15 MB, always display input element

### DIFF
--- a/packages/design-system/components/Dropzone/index.tsx
+++ b/packages/design-system/components/Dropzone/index.tsx
@@ -1,6 +1,6 @@
-import { FC, useState } from 'react'
+import React, { FC, useState } from 'react'
 
-import { getImageString } from '@baseapp-frontend/utils'
+import { getImageString, useNotification } from '@baseapp-frontend/utils'
 
 import { Box, Button, Card, Typography } from '@mui/material'
 import { useDropzone } from 'react-dropzone'
@@ -24,11 +24,16 @@ const Dropzone: FC<DropzoneProps> = ({
   DropzoneOptions,
 }) => {
   const [files, setFiles] = useState<string | undefined>(storedImg)
+  const { sendToast } = useNotification()
 
   const { open, getRootProps, getInputProps, isFocused, isDragAccept, isDragReject } = useDropzone({
     accept,
     onDrop: async (acceptedFiles: any) => {
       if (acceptedFiles.length === 0) return
+      if (acceptedFiles[0].size > 15 * 1024 * 1024) {
+        sendToast('This file is too large (max 15 MB).', { type: 'error' })
+        return
+      }
       const imgString = await getImageString(acceptedFiles[0])
       if (!imgString) return
       setFiles(imgString)
@@ -45,20 +50,23 @@ const Dropzone: FC<DropzoneProps> = ({
   const renderContent = () => {
     if (files)
       return (
-        <Card>
-          <Box p={2} display="flex" flexDirection="column" alignItems="center">
-            <img
-              key={files}
-              src={files}
-              alt="preview"
-              style={{ maxHeight: '200px', maxWidth: '100%' }}
-            />
-          </Box>
-        </Card>
+        <>
+          <input {...getInputProps()} />
+          <Card>
+            <Box p={2} display="flex" flexDirection="column" alignItems="center">
+              <img
+                key={files}
+                src={files}
+                alt="preview"
+                style={{ maxHeight: '200px', maxWidth: '100%' }}
+              />
+            </Box>
+          </Card>
+        </>
       )
 
     return (
-      <div className="w-full container max-w-none">
+      <div className="container w-full max-w-none">
         <InputContainer {...getRootProps({ isFocused, isDragAccept, isDragReject })}>
           <input {...getInputProps()} />
           {isDragReject ? (


### PR DESCRIPTION
- Restricts uploads to the dropzone to files <15 MB
- Always displays the dropzone input element. This fixes the following bug: Currently, after uploading an image the `Change Image` button has no effect: It tries to open the dropzone file input, but there is none.

Does anybody know where the original limitation to file sizes <15 MiB came from? Afaik, local storage is limited to 5 MiB. Surprisingly (?), I do not always get an error when trying to upload larger files. Anyway, I would also suggest to reduce the maximum file size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `Dropzone` component with notification capabilities for file size validation.
	- Users receive notifications if uploaded files exceed 15 MB.

- **Improvements**
	- Improved organization of the component's JSX structure for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->