### PR TITLE
Ba 1776 do not allow upload of too large logo

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/components
 
+## 0.0.17
+
+### Patch Changes
+
+Updated dependencies
+  - @baseapp-frontend/design-system@0.0.17
+
 ## 0.0.16
 
 ### Patch Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/design-system
 
+## 0.0.18
+
+### Patch Changes
+
+- Impose file size limits on Dropzones
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/design-system/components/Dropzone/index.tsx
+++ b/packages/design-system/components/Dropzone/index.tsx
@@ -1,6 +1,6 @@
-import { FC, useState } from 'react'
+import React, { FC, useState } from 'react'
 
-import { getImageString } from '@baseapp-frontend/utils'
+import { getImageString, useNotification } from '@baseapp-frontend/utils'
 
 import { Box, Button, Card, Typography } from '@mui/material'
 import { useDropzone } from 'react-dropzone'
@@ -24,11 +24,16 @@ const Dropzone: FC<DropzoneProps> = ({
   DropzoneOptions,
 }) => {
   const [files, setFiles] = useState<string | undefined>(storedImg)
+  const { sendToast } = useNotification()
 
   const { open, getRootProps, getInputProps, isFocused, isDragAccept, isDragReject } = useDropzone({
     accept,
     onDrop: async (acceptedFiles: any) => {
       if (acceptedFiles.length === 0) return
+      if (acceptedFiles[0].size > 15 * 1024 * 1024) {
+        sendToast('This file is too large (max 15 MB).', { type: 'error' })
+        return
+      }
       const imgString = await getImageString(acceptedFiles[0])
       if (!imgString) return
       setFiles(imgString)
@@ -45,20 +50,23 @@ const Dropzone: FC<DropzoneProps> = ({
   const renderContent = () => {
     if (files)
       return (
-        <Card>
-          <Box p={2} display="flex" flexDirection="column" alignItems="center">
-            <img
-              key={files}
-              src={files}
-              alt="preview"
-              style={{ maxHeight: '200px', maxWidth: '100%' }}
-            />
-          </Box>
-        </Card>
+        <>
+          <input {...getInputProps()} />
+          <Card>
+            <Box p={2} display="flex" flexDirection="column" alignItems="center">
+              <img
+                key={files}
+                src={files}
+                alt="preview"
+                style={{ maxHeight: '200px', maxWidth: '100%' }}
+              />
+            </Box>
+          </Card>
+        </>
       )
 
     return (
-      <div className="w-full container max-w-none">
+      <div className="container w-full max-w-none">
         <InputContainer {...getRootProps({ isFocused, isDragAccept, isDragReject })}>
           <input {...getInputProps()} />
           {isDragReject ? (

--- a/packages/design-system/components/Dropzone/index.tsx
+++ b/packages/design-system/components/Dropzone/index.tsx
@@ -20,7 +20,8 @@ const Dropzone: FC<DropzoneProps> = ({
   onSelect,
   onRemove,
   actionText = 'Upload Image',
-  subTitle = 'Max. File Size: 15MB',
+  maxFileSize = 15,
+  subTitle = `Max. File Size: ${maxFileSize}MB`,
   DropzoneOptions,
 }) => {
   const [files, setFiles] = useState<string | undefined>(storedImg)
@@ -30,8 +31,8 @@ const Dropzone: FC<DropzoneProps> = ({
     accept,
     onDrop: async (acceptedFiles: any) => {
       if (acceptedFiles.length === 0) return
-      if (acceptedFiles[0].size > 15 * 1024 * 1024) {
-        sendToast('This file is too large (max 15 MB).', { type: 'error' })
+      if (acceptedFiles[0].size > maxFileSize * 1024 * 1024) {
+        sendToast(`This file is too large (max ${maxFileSize} MB).`, { type: 'error' })
         return
       }
       const imgString = await getImageString(acceptedFiles[0])

--- a/packages/design-system/components/Dropzone/types.ts
+++ b/packages/design-system/components/Dropzone/types.ts
@@ -15,5 +15,6 @@ export interface DropzoneProps {
   onRemove: () => void
   actionText?: string
   subTitle?: string
+  maxFileSize?: number
   DropzoneOptions?: Partial<DropzoneOptions>
 }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/design-system",
   "description": "Design System components and configurations.",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
- Restricts uploads to the `Dropzone` to files smaller than a certain maximum size
- This maximum size defaults to 15 MB, but can be customized
- The bug that the Change Image button has no effect when an image is already uploaded is resolved (the dropzone input element is always displayed, so that the file input can open when clicking the Change Image button).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a maximum file size limit for uploads in the Dropzone component, enhancing user experience during file uploads.
  
- **Dependency Updates**
  - Updated the `@baseapp-frontend/design-system` dependency to version `0.0.17` and `0.0.18` for improved functionality and stability.

- **Changelog Updates**
  - Updated changelogs for both components and design system packages to document recent changes and version updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->