### PR TITLE
Make sure listener is loaded only once in useCurrentProfile

### DIFF
--- a/packages/authentication/CHANGELOG.md
+++ b/packages/authentication/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/authentication
 
+## 4.0.4
+
+### Patch Changes
+
+- Make sure the log out listener is loaded only once in useCurrentProfile
+
 ## 4.0.3
 
 ### Patch Changes

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/components
 
+## 0.0.25
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/authentication@4.0.4
+
 ## 0.0.24
 
 ### Patch Changes


### PR DESCRIPTION
Bug fix: Make sure that the log out listener is loaded only once in `useCurrentProfile`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the authentication package to version 4.0.4, enhancing logout listener behavior.
  
- **Bug Fixes**
	- Streamlined logout event management within the profile atom for improved performance.

- **Documentation**
	- Changelog updated to reflect new versions and significant changes in the authentication package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->