### PR TITLE
BA: add dropzone aria label

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/components
 
+## 0.0.31
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/design-system@0.0.23
+
 ## 0.0.30
 
 ### Patch Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/design-system
 
+## 0.0.23
+
+### Patch Changes
+
+- Add `InputProps` prop and a default `aria-label` to the input.
+
 ## 0.0.22
 
 ### Patch Changes

--- a/packages/design-system/components/Dropzone/index.tsx
+++ b/packages/design-system/components/Dropzone/index.tsx
@@ -23,6 +23,7 @@ const Dropzone: FC<DropzoneProps> = ({
   maxFileSize = 15,
   subTitle = `Max. File Size: ${maxFileSize}MB`,
   DropzoneOptions,
+  InputProps,
 }) => {
   const [files, setFiles] = useState<string | undefined>(storedImg)
   const { sendToast } = useNotification()
@@ -49,10 +50,12 @@ const Dropzone: FC<DropzoneProps> = ({
   }
 
   const renderContent = () => {
+    const ariaLabel = 'Drag and drop files to upload'
+
     if (files)
       return (
         <>
-          <input {...getInputProps()} />
+          <input {...getInputProps()} aria-label={ariaLabel} {...InputProps} />
           <Card>
             <Box p={2} display="flex" flexDirection="column" alignItems="center">
               <img
@@ -69,7 +72,7 @@ const Dropzone: FC<DropzoneProps> = ({
     return (
       <div className="container w-full max-w-none">
         <InputContainer {...getRootProps({ isFocused, isDragAccept, isDragReject })}>
-          <input {...getInputProps()} />
+          <input {...getInputProps()} aria-label={ariaLabel} {...InputProps} />
           {isDragReject ? (
             <>
               <CancelIcon />

--- a/packages/design-system/components/Dropzone/types.ts
+++ b/packages/design-system/components/Dropzone/types.ts
@@ -1,3 +1,5 @@
+import { InputHTMLAttributes } from 'react'
+
 import { Theme } from '@mui/material/styles'
 import type { Accept, DropzoneOptions } from 'react-dropzone'
 
@@ -17,4 +19,5 @@ export interface DropzoneProps {
   subTitle?: string
   maxFileSize?: number
   DropzoneOptions?: Partial<DropzoneOptions>
+  InputProps?: InputHTMLAttributes<HTMLInputElement>
 }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/design-system",
   "description": "Design System components and configurations.",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/wagtail/CHANGELOG.md
+++ b/packages/wagtail/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/wagtail
 
+## 1.0.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/design-system@0.0.23
+
 ## 1.0.6
 
 ### Patch Changes

--- a/packages/wagtail/package.json
+++ b/packages/wagtail/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/wagtail",
   "description": "BaseApp Wagtail",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
- `design-system` package update - `v 0.0.23`
  - Add `InputProps` prop and a default `aria-label` to the input.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new property, `InputProps`, to the input component for enhanced customization and accessibility.
  
- **Bug Fixes**
	- Improved accessibility of the `Dropzone` component by incorporating `aria-label` for input elements.

- **Chores**
	- Updated version numbers for the `@baseapp-frontend/components`, `@baseapp-frontend/design-system`, and `@baseapp-frontend/wagtail` packages to reflect recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->