### PR TITLE
BA-1934 [FE packages] Mark Chat as Unread

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,11 +1,18 @@
 # @baseapp-frontend/components
 
+## 0.0.36
+
+### Patch Changes
+
+- Graphql mutation for unreading chats introduced
+- Graphql field unreadMessagesCount is replaced by a count field on unreadMessages (which also has a markedUnread field)
+
 ## 0.0.35
 
 ### Patch Changes
 
 - Updated dependencies
-  - @baseapp-frontend/graphql@1.1.14
+- @baseapp-frontend/graphql@1.1.14
 
 ## 0.0.34
 

--- a/packages/components/__generated__/ChatRoomMessagesListPaginationQuery.graphql.ts
+++ b/packages/components/__generated__/ChatRoomMessagesListPaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<dab2b6d7ef084dd3081093aa6468bb4a>>
+ * @generated SignedSource<<c0ae600617cd934b832228f24591f1f7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -157,8 +157,26 @@ const node: ConcreteRequest = (function () {
                 {
                   alias: null,
                   args: null,
-                  kind: 'ScalarField',
-                  name: 'unreadMessagesCount',
+                  concreteType: 'UnreadMessages',
+                  kind: 'LinkedField',
+                  name: 'unreadMessages',
+                  plural: false,
+                  selections: [
+                    {
+                      alias: null,
+                      args: null,
+                      kind: 'ScalarField',
+                      name: 'count',
+                      storageKey: null,
+                    },
+                    {
+                      alias: null,
+                      args: null,
+                      kind: 'ScalarField',
+                      name: 'markedUnread',
+                      storageKey: null,
+                    },
+                  ],
                   storageKey: null,
                 },
                 {
@@ -348,16 +366,16 @@ const node: ConcreteRequest = (function () {
       ],
     },
     params: {
-      cacheID: '49f246acb3d0ddfb7b9b7cc486130a76',
+      cacheID: 'bfd8d21c03b208e2901e4fe25aeb55ac',
       id: null,
       metadata: {},
       name: 'ChatRoomMessagesListPaginationQuery',
       operationKind: 'query',
-      text: 'query ChatRoomMessagesListPaginationQuery(\n  $count: Int = 20\n  $cursor: String\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...MessagesListFragment_1G22uz\n    id\n  }\n}\n\nfragment MessageItemFragment on Message {\n  id\n  content\n  created\n  extraData\n  inReplyTo {\n    id\n  }\n  isRead\n  pk\n  profile {\n    id\n  }\n  verb\n}\n\nfragment MessagesListFragment_1G22uz on ChatRoom {\n  id\n  participants {\n    totalCount\n  }\n  unreadMessagesCount\n  allMessages(first: $count, after: $cursor) {\n    totalCount\n    edges {\n      node {\n        id\n        created\n        profile {\n          id\n          name\n          image(height: 32, width: 32) {\n            url\n          }\n        }\n        isRead\n        ...MessageItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n',
+      text: 'query ChatRoomMessagesListPaginationQuery(\n  $count: Int = 20\n  $cursor: String\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...MessagesListFragment_1G22uz\n    id\n  }\n}\n\nfragment MessageItemFragment on Message {\n  id\n  content\n  created\n  extraData\n  inReplyTo {\n    id\n  }\n  isRead\n  pk\n  profile {\n    id\n  }\n  verb\n}\n\nfragment MessagesListFragment_1G22uz on ChatRoom {\n  id\n  participants {\n    totalCount\n  }\n  unreadMessages {\n    count\n    markedUnread\n  }\n  allMessages(first: $count, after: $cursor) {\n    totalCount\n    edges {\n      node {\n        id\n        created\n        profile {\n          id\n          name\n          image(height: 32, width: 32) {\n            url\n          }\n        }\n        isRead\n        ...MessageItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n',
     },
   }
 })()
 
-;(node as any).hash = '1eebe2365c138d57d71fb4d1365102b9'
+;(node as any).hash = '8137c492c793a174c334ca5178c5ce22'
 
 export default node

--- a/packages/components/__generated__/ChatRoomQuery.graphql.ts
+++ b/packages/components/__generated__/ChatRoomQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8ee140d8fcda94cbadcfae93ce3159e6>>
+ * @generated SignedSource<<e5c49e7251ae70593a18c6124a3d6d2d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -207,8 +207,26 @@ const node: ConcreteRequest = (function () {
             {
               alias: null,
               args: null,
-              kind: 'ScalarField',
-              name: 'unreadMessagesCount',
+              concreteType: 'UnreadMessages',
+              kind: 'LinkedField',
+              name: 'unreadMessages',
+              plural: false,
+              selections: [
+                {
+                  alias: null,
+                  args: null,
+                  kind: 'ScalarField',
+                  name: 'count',
+                  storageKey: null,
+                },
+                {
+                  alias: null,
+                  args: null,
+                  kind: 'ScalarField',
+                  name: 'markedUnread',
+                  storageKey: null,
+                },
+              ],
               storageKey: null,
             },
             {
@@ -386,12 +404,12 @@ const node: ConcreteRequest = (function () {
       ],
     },
     params: {
-      cacheID: '1be7817039d0266ae5f5a59e70f3cae3',
+      cacheID: '4f5e1119794e184995aef3553f6e5fc0',
       id: null,
       metadata: {},
       name: 'ChatRoomQuery',
       operationKind: 'query',
-      text: 'query ChatRoomQuery(\n  $roomId: ID!\n) {\n  chatRoom(id: $roomId) {\n    id\n    ...ChatRoomHeaderFragment\n    ...MessagesListFragment\n  }\n}\n\nfragment ChatRoomHeaderFragment on ChatRoom {\n  image(width: 100, height: 100) {\n    url\n  }\n  title\n  participants {\n    edges {\n      node {\n        profile {\n          id\n          name\n          image(width: 100, height: 100) {\n            url\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MessageItemFragment on Message {\n  id\n  content\n  created\n  extraData\n  inReplyTo {\n    id\n  }\n  isRead\n  pk\n  profile {\n    id\n  }\n  verb\n}\n\nfragment MessagesListFragment on ChatRoom {\n  id\n  participants {\n    totalCount\n  }\n  unreadMessagesCount\n  allMessages(first: 20) {\n    totalCount\n    edges {\n      node {\n        id\n        created\n        profile {\n          id\n          name\n          image(height: 32, width: 32) {\n            url\n          }\n        }\n        isRead\n        ...MessageItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n',
+      text: 'query ChatRoomQuery(\n  $roomId: ID!\n) {\n  chatRoom(id: $roomId) {\n    id\n    ...ChatRoomHeaderFragment\n    ...MessagesListFragment\n  }\n}\n\nfragment ChatRoomHeaderFragment on ChatRoom {\n  image(width: 100, height: 100) {\n    url\n  }\n  title\n  participants {\n    edges {\n      node {\n        profile {\n          id\n          name\n          image(width: 100, height: 100) {\n            url\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MessageItemFragment on Message {\n  id\n  content\n  created\n  extraData\n  inReplyTo {\n    id\n  }\n  isRead\n  pk\n  profile {\n    id\n  }\n  verb\n}\n\nfragment MessagesListFragment on ChatRoom {\n  id\n  participants {\n    totalCount\n  }\n  unreadMessages {\n    count\n    markedUnread\n  }\n  allMessages(first: 20) {\n    totalCount\n    edges {\n      node {\n        id\n        created\n        profile {\n          id\n          name\n          image(height: 32, width: 32) {\n            url\n          }\n        }\n        isRead\n        ...MessageItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n',
     },
   }
 })()

--- a/packages/components/__generated__/ChatRoomsQuery.graphql.ts
+++ b/packages/components/__generated__/ChatRoomsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<43f91ec4dc055bc7109f9c12c6fa346a>>
+ * @generated SignedSource<<1b323607818160897b0a6ff121fc78ca>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -332,8 +332,26 @@ const node: ConcreteRequest = (function () {
                                 {
                                   alias: null,
                                   args: null,
-                                  kind: 'ScalarField',
-                                  name: 'unreadMessagesCount',
+                                  concreteType: 'UnreadMessages',
+                                  kind: 'LinkedField',
+                                  name: 'unreadMessages',
+                                  plural: false,
+                                  selections: [
+                                    {
+                                      alias: null,
+                                      args: null,
+                                      kind: 'ScalarField',
+                                      name: 'count',
+                                      storageKey: null,
+                                    },
+                                    {
+                                      alias: null,
+                                      args: null,
+                                      kind: 'ScalarField',
+                                      name: 'markedUnread',
+                                      storageKey: null,
+                                    },
+                                  ],
                                   storageKey: null,
                                 },
                                 {
@@ -571,12 +589,12 @@ const node: ConcreteRequest = (function () {
       ],
     },
     params: {
-      cacheID: 'f8b0b4c3bd559ad17b832e9bdfb3a919',
+      cacheID: '7bbfb495d5690e7598b6716da8589bea',
       id: null,
       metadata: {},
       name: 'ChatRoomsQuery',
       operationKind: 'query',
-      text: 'query ChatRoomsQuery {\n  ...AllProfilesListFragment\n  me {\n    id\n    profile {\n      id\n      ...RoomsListFragment\n    }\n  }\n}\n\nfragment AllProfilesListFragment on Query {\n  allProfiles(first: 5, orderBy: "-created") {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        ...ProfileItemFragment\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment ChatRoomHeaderFragment on ChatRoom {\n  image(width: 100, height: 100) {\n    url\n  }\n  title\n  participants {\n    edges {\n      node {\n        profile {\n          id\n          name\n          image(width: 100, height: 100) {\n            url\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MessageItemFragment on Message {\n  id\n  content\n  created\n  extraData\n  inReplyTo {\n    id\n  }\n  isRead\n  pk\n  profile {\n    id\n  }\n  verb\n}\n\nfragment MessagesListFragment on ChatRoom {\n  id\n  participants {\n    totalCount\n  }\n  unreadMessagesCount\n  allMessages(first: 20) {\n    totalCount\n    edges {\n      node {\n        id\n        created\n        profile {\n          id\n          name\n          image(height: 32, width: 32) {\n            url\n          }\n        }\n        isRead\n        ...MessageItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment ProfileItemFragment on Profile {\n  id\n  name\n  image(width: 100, height: 100) {\n    url\n  }\n  urlPath {\n    path\n    id\n  }\n}\n\nfragment RoomFragment on ChatRoom {\n  id\n  unreadMessagesCount\n  lastMessageTime\n  lastMessage {\n    id\n    content\n  }\n  ...ChatRoomHeaderFragment\n  ...MessagesListFragment\n}\n\nfragment RoomsListFragment on ChatRoomsInterface {\n  __isChatRoomsInterface: __typename\n  chatRooms(first: 5, unreadMessages: false, archived: false) {\n    edges {\n      node {\n        id\n        ...RoomFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n  id\n}\n',
+      text: 'query ChatRoomsQuery {\n  ...AllProfilesListFragment\n  me {\n    id\n    profile {\n      id\n      ...RoomsListFragment\n    }\n  }\n}\n\nfragment AllProfilesListFragment on Query {\n  allProfiles(first: 5, orderBy: "-created") {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    edges {\n      node {\n        id\n        ...ProfileItemFragment\n        __typename\n      }\n      cursor\n    }\n  }\n}\n\nfragment ChatRoomHeaderFragment on ChatRoom {\n  image(width: 100, height: 100) {\n    url\n  }\n  title\n  participants {\n    edges {\n      node {\n        profile {\n          id\n          name\n          image(width: 100, height: 100) {\n            url\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MessageItemFragment on Message {\n  id\n  content\n  created\n  extraData\n  inReplyTo {\n    id\n  }\n  isRead\n  pk\n  profile {\n    id\n  }\n  verb\n}\n\nfragment MessagesListFragment on ChatRoom {\n  id\n  participants {\n    totalCount\n  }\n  unreadMessages {\n    count\n    markedUnread\n  }\n  allMessages(first: 20) {\n    totalCount\n    edges {\n      node {\n        id\n        created\n        profile {\n          id\n          name\n          image(height: 32, width: 32) {\n            url\n          }\n        }\n        isRead\n        ...MessageItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment ProfileItemFragment on Profile {\n  id\n  name\n  image(width: 100, height: 100) {\n    url\n  }\n  urlPath {\n    path\n    id\n  }\n}\n\nfragment RoomFragment on ChatRoom {\n  id\n  unreadMessages {\n    count\n    markedUnread\n  }\n  lastMessageTime\n  lastMessage {\n    id\n    content\n  }\n  ...ChatRoomHeaderFragment\n  ...MessagesListFragment\n}\n\nfragment RoomsListFragment on ChatRoomsInterface {\n  __isChatRoomsInterface: __typename\n  chatRooms(first: 5, unreadMessages: false, archived: false) {\n    edges {\n      node {\n        id\n        ...RoomFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n  id\n}\n',
     },
   }
 })()

--- a/packages/components/__generated__/CreateChatRoomMutation.graphql.ts
+++ b/packages/components/__generated__/CreateChatRoomMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<61cf9f01f1fb97c3e5efe797b0cfaf4e>>
+ * @generated SignedSource<<43514a1c6cbb856a35e531c83522581e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -343,8 +343,26 @@ const node: ConcreteRequest = (function () {
                     {
                       alias: null,
                       args: null,
-                      kind: 'ScalarField',
-                      name: 'unreadMessagesCount',
+                      concreteType: 'UnreadMessages',
+                      kind: 'LinkedField',
+                      name: 'unreadMessages',
+                      plural: false,
+                      selections: [
+                        {
+                          alias: null,
+                          args: null,
+                          kind: 'ScalarField',
+                          name: 'count',
+                          storageKey: null,
+                        },
+                        {
+                          alias: null,
+                          args: null,
+                          kind: 'ScalarField',
+                          name: 'markedUnread',
+                          storageKey: null,
+                        },
+                      ],
                       storageKey: null,
                     },
                     {
@@ -564,12 +582,12 @@ const node: ConcreteRequest = (function () {
       ],
     },
     params: {
-      cacheID: '1de5bc3b81a673f0a5442a0462175c63',
+      cacheID: '78d61980ce3fed08c783745e4ffa7587',
       id: null,
       metadata: {},
       name: 'CreateChatRoomMutation',
       operationKind: 'mutation',
-      text: 'mutation CreateChatRoomMutation(\n  $input: ChatRoomCreateInput!\n) {\n  chatRoomCreate(input: $input) {\n    room {\n      node {\n        id\n        participants {\n          edges {\n            node {\n              id\n            }\n          }\n        }\n        ...RoomFragment\n      }\n    }\n    errors {\n      field\n      messages\n    }\n  }\n}\n\nfragment ChatRoomHeaderFragment on ChatRoom {\n  image(width: 100, height: 100) {\n    url\n  }\n  title\n  participants {\n    edges {\n      node {\n        profile {\n          id\n          name\n          image(width: 100, height: 100) {\n            url\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MessageItemFragment on Message {\n  id\n  content\n  created\n  extraData\n  inReplyTo {\n    id\n  }\n  isRead\n  pk\n  profile {\n    id\n  }\n  verb\n}\n\nfragment MessagesListFragment on ChatRoom {\n  id\n  participants {\n    totalCount\n  }\n  unreadMessagesCount\n  allMessages(first: 20) {\n    totalCount\n    edges {\n      node {\n        id\n        created\n        profile {\n          id\n          name\n          image(height: 32, width: 32) {\n            url\n          }\n        }\n        isRead\n        ...MessageItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment RoomFragment on ChatRoom {\n  id\n  unreadMessagesCount\n  lastMessageTime\n  lastMessage {\n    id\n    content\n  }\n  ...ChatRoomHeaderFragment\n  ...MessagesListFragment\n}\n',
+      text: 'mutation CreateChatRoomMutation(\n  $input: ChatRoomCreateInput!\n) {\n  chatRoomCreate(input: $input) {\n    room {\n      node {\n        id\n        participants {\n          edges {\n            node {\n              id\n            }\n          }\n        }\n        ...RoomFragment\n      }\n    }\n    errors {\n      field\n      messages\n    }\n  }\n}\n\nfragment ChatRoomHeaderFragment on ChatRoom {\n  image(width: 100, height: 100) {\n    url\n  }\n  title\n  participants {\n    edges {\n      node {\n        profile {\n          id\n          name\n          image(width: 100, height: 100) {\n            url\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MessageItemFragment on Message {\n  id\n  content\n  created\n  extraData\n  inReplyTo {\n    id\n  }\n  isRead\n  pk\n  profile {\n    id\n  }\n  verb\n}\n\nfragment MessagesListFragment on ChatRoom {\n  id\n  participants {\n    totalCount\n  }\n  unreadMessages {\n    count\n    markedUnread\n  }\n  allMessages(first: 20) {\n    totalCount\n    edges {\n      node {\n        id\n        created\n        profile {\n          id\n          name\n          image(height: 32, width: 32) {\n            url\n          }\n        }\n        isRead\n        ...MessageItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment RoomFragment on ChatRoom {\n  id\n  unreadMessages {\n    count\n    markedUnread\n  }\n  lastMessageTime\n  lastMessage {\n    id\n    content\n  }\n  ...ChatRoomHeaderFragment\n  ...MessagesListFragment\n}\n',
     },
   }
 })()

--- a/packages/components/__generated__/MessagesListFragment.graphql.ts
+++ b/packages/components/__generated__/MessagesListFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<91b489da3df08f0b62ec9dce25b08a58>>
+ * @generated SignedSource<<8340b33c4779ab7d8426e74e1ec2236f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -57,7 +57,13 @@ export type MessagesListFragment$data = {
       }
     | null
     | undefined
-  readonly unreadMessagesCount: number | null | undefined
+  readonly unreadMessages:
+    | {
+        readonly count: number | null | undefined
+        readonly markedUnread: boolean | null | undefined
+      }
+    | null
+    | undefined
   readonly ' $fragmentType': 'MessagesListFragment'
 }
 export type MessagesListFragment$key = {
@@ -137,8 +143,26 @@ const node: ReaderFragment = (function () {
       {
         alias: null,
         args: null,
-        kind: 'ScalarField',
-        name: 'unreadMessagesCount',
+        concreteType: 'UnreadMessages',
+        kind: 'LinkedField',
+        name: 'unreadMessages',
+        plural: false,
+        selections: [
+          {
+            alias: null,
+            args: null,
+            kind: 'ScalarField',
+            name: 'count',
+            storageKey: null,
+          },
+          {
+            alias: null,
+            args: null,
+            kind: 'ScalarField',
+            name: 'markedUnread',
+            storageKey: null,
+          },
+        ],
         storageKey: null,
       },
       {
@@ -288,6 +312,6 @@ const node: ReaderFragment = (function () {
   }
 })()
 
-;(node as any).hash = '1eebe2365c138d57d71fb4d1365102b9'
+;(node as any).hash = '8137c492c793a174c334ca5178c5ce22'
 
 export default node

--- a/packages/components/__generated__/ReadMessagesMutation.graphql.ts
+++ b/packages/components/__generated__/ReadMessagesMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f9246983f2bfd33796f23d8c3b111130>>
+ * @generated SignedSource<<2f9b0ec06977248c81c9044cc03ab7e3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -37,7 +37,13 @@ export type ReadMessagesMutation$data = {
         readonly room:
           | {
               readonly id: string
-              readonly unreadMessagesCount: number | null | undefined
+              readonly unreadMessages:
+                | {
+                    readonly count: number | null | undefined
+                    readonly markedUnread: boolean | null | undefined
+                  }
+                | null
+                | undefined
               readonly ' $fragmentSpreads': FragmentRefs<'RoomFragment'>
             }
           | null
@@ -76,8 +82,26 @@ const node: ConcreteRequest = (function () {
     v3 = {
       alias: null,
       args: null,
-      kind: 'ScalarField',
-      name: 'unreadMessagesCount',
+      concreteType: 'UnreadMessages',
+      kind: 'LinkedField',
+      name: 'unreadMessages',
+      plural: false,
+      selections: [
+        {
+          alias: null,
+          args: null,
+          kind: 'ScalarField',
+          name: 'count',
+          storageKey: null,
+        },
+        {
+          alias: null,
+          args: null,
+          kind: 'ScalarField',
+          name: 'markedUnread',
+          storageKey: null,
+        },
+      ],
       storageKey: null,
     },
     v4 = {
@@ -471,16 +495,16 @@ const node: ConcreteRequest = (function () {
       ],
     },
     params: {
-      cacheID: '8a73bdda098595a81d4e8237dc2977b6',
+      cacheID: '16aa5685f87fd675f7dd450bdc29fd04',
       id: null,
       metadata: {},
       name: 'ReadMessagesMutation',
       operationKind: 'mutation',
-      text: 'mutation ReadMessagesMutation(\n  $input: ChatRoomReadMessagesInput!\n) {\n  chatRoomReadMessages(input: $input) {\n    room {\n      id\n      unreadMessagesCount\n      ...RoomFragment\n    }\n    errors {\n      field\n      messages\n    }\n  }\n}\n\nfragment ChatRoomHeaderFragment on ChatRoom {\n  image(width: 100, height: 100) {\n    url\n  }\n  title\n  participants {\n    edges {\n      node {\n        profile {\n          id\n          name\n          image(width: 100, height: 100) {\n            url\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MessageItemFragment on Message {\n  id\n  content\n  created\n  extraData\n  inReplyTo {\n    id\n  }\n  isRead\n  pk\n  profile {\n    id\n  }\n  verb\n}\n\nfragment MessagesListFragment on ChatRoom {\n  id\n  participants {\n    totalCount\n  }\n  unreadMessagesCount\n  allMessages(first: 20) {\n    totalCount\n    edges {\n      node {\n        id\n        created\n        profile {\n          id\n          name\n          image(height: 32, width: 32) {\n            url\n          }\n        }\n        isRead\n        ...MessageItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment RoomFragment on ChatRoom {\n  id\n  unreadMessagesCount\n  lastMessageTime\n  lastMessage {\n    id\n    content\n  }\n  ...ChatRoomHeaderFragment\n  ...MessagesListFragment\n}\n',
+      text: 'mutation ReadMessagesMutation(\n  $input: ChatRoomReadMessagesInput!\n) {\n  chatRoomReadMessages(input: $input) {\n    room {\n      id\n      unreadMessages {\n        count\n        markedUnread\n      }\n      ...RoomFragment\n    }\n    errors {\n      field\n      messages\n    }\n  }\n}\n\nfragment ChatRoomHeaderFragment on ChatRoom {\n  image(width: 100, height: 100) {\n    url\n  }\n  title\n  participants {\n    edges {\n      node {\n        profile {\n          id\n          name\n          image(width: 100, height: 100) {\n            url\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MessageItemFragment on Message {\n  id\n  content\n  created\n  extraData\n  inReplyTo {\n    id\n  }\n  isRead\n  pk\n  profile {\n    id\n  }\n  verb\n}\n\nfragment MessagesListFragment on ChatRoom {\n  id\n  participants {\n    totalCount\n  }\n  unreadMessages {\n    count\n    markedUnread\n  }\n  allMessages(first: 20) {\n    totalCount\n    edges {\n      node {\n        id\n        created\n        profile {\n          id\n          name\n          image(height: 32, width: 32) {\n            url\n          }\n        }\n        isRead\n        ...MessageItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment RoomFragment on ChatRoom {\n  id\n  unreadMessages {\n    count\n    markedUnread\n  }\n  lastMessageTime\n  lastMessage {\n    id\n    content\n  }\n  ...ChatRoomHeaderFragment\n  ...MessagesListFragment\n}\n',
     },
   }
 })()
 
-;(node as any).hash = '5e16432139531f48bfb558baf5270f82'
+;(node as any).hash = '74e8ca248a5168c5ce8623b79103f75d'
 
 export default node

--- a/packages/components/__generated__/RoomFragment.graphql.ts
+++ b/packages/components/__generated__/RoomFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3ff677fac515b53b8e1eeddd770cf81d>>
+ * @generated SignedSource<<7c1fd5222de7db808df5694f5b913743>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,7 +21,13 @@ export type RoomFragment$data = {
     | null
     | undefined
   readonly lastMessageTime: any | null | undefined
-  readonly unreadMessagesCount: number | null | undefined
+  readonly unreadMessages:
+    | {
+        readonly count: number | null | undefined
+        readonly markedUnread: boolean | null | undefined
+      }
+    | null
+    | undefined
   readonly ' $fragmentSpreads': FragmentRefs<'ChatRoomHeaderFragment' | 'MessagesListFragment'>
   readonly ' $fragmentType': 'RoomFragment'
 }
@@ -48,8 +54,26 @@ const node: ReaderFragment = (function () {
       {
         alias: null,
         args: null,
-        kind: 'ScalarField',
-        name: 'unreadMessagesCount',
+        concreteType: 'UnreadMessages',
+        kind: 'LinkedField',
+        name: 'unreadMessages',
+        plural: false,
+        selections: [
+          {
+            alias: null,
+            args: null,
+            kind: 'ScalarField',
+            name: 'count',
+            storageKey: null,
+          },
+          {
+            alias: null,
+            args: null,
+            kind: 'ScalarField',
+            name: 'markedUnread',
+            storageKey: null,
+          },
+        ],
         storageKey: null,
       },
       {
@@ -94,6 +118,6 @@ const node: ReaderFragment = (function () {
   }
 })()
 
-;(node as any).hash = '9d4bfcdfca9ea94693b2ebb241c58e9f'
+;(node as any).hash = '07844e29548083b80a887e96cfddd508'
 
 export default node

--- a/packages/components/__generated__/UnreadChatMutation.graphql.ts
+++ b/packages/components/__generated__/UnreadChatMutation.graphql.ts
@@ -1,0 +1,182 @@
+/**
+ * @generated SignedSource<<02b8381612f47b357400105930f18b82>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+
+/* eslint-disable */
+// @ts-nocheck
+import { ConcreteRequest, Mutation } from 'relay-runtime'
+
+export type ChatRoomUnreadInput = {
+  clientMutationId?: string | null | undefined
+  profileId: string
+  roomId: string
+}
+export type UnreadChatMutation$variables = {
+  input: ChatRoomUnreadInput
+}
+export type UnreadChatMutation$data = {
+  readonly chatRoomUnread:
+    | {
+        readonly errors:
+          | ReadonlyArray<
+              | {
+                  readonly field: string
+                  readonly messages: ReadonlyArray<string>
+                }
+              | null
+              | undefined
+            >
+          | null
+          | undefined
+        readonly room:
+          | {
+              readonly id: string
+              readonly unreadMessages:
+                | {
+                    readonly count: number | null | undefined
+                    readonly markedUnread: boolean | null | undefined
+                  }
+                | null
+                | undefined
+            }
+          | null
+          | undefined
+      }
+    | null
+    | undefined
+}
+export type UnreadChatMutation = {
+  response: UnreadChatMutation$data
+  variables: UnreadChatMutation$variables
+}
+
+const node: ConcreteRequest = (function () {
+  var v0 = [
+      {
+        defaultValue: null,
+        kind: 'LocalArgument',
+        name: 'input',
+      },
+    ],
+    v1 = [
+      {
+        alias: null,
+        args: [
+          {
+            kind: 'Variable',
+            name: 'input',
+            variableName: 'input',
+          },
+        ],
+        concreteType: 'ChatRoomUnreadPayload',
+        kind: 'LinkedField',
+        name: 'chatRoomUnread',
+        plural: false,
+        selections: [
+          {
+            alias: null,
+            args: null,
+            concreteType: 'ChatRoom',
+            kind: 'LinkedField',
+            name: 'room',
+            plural: false,
+            selections: [
+              {
+                alias: null,
+                args: null,
+                kind: 'ScalarField',
+                name: 'id',
+                storageKey: null,
+              },
+              {
+                alias: null,
+                args: null,
+                concreteType: 'UnreadMessages',
+                kind: 'LinkedField',
+                name: 'unreadMessages',
+                plural: false,
+                selections: [
+                  {
+                    alias: null,
+                    args: null,
+                    kind: 'ScalarField',
+                    name: 'count',
+                    storageKey: null,
+                  },
+                  {
+                    alias: null,
+                    args: null,
+                    kind: 'ScalarField',
+                    name: 'markedUnread',
+                    storageKey: null,
+                  },
+                ],
+                storageKey: null,
+              },
+            ],
+            storageKey: null,
+          },
+          {
+            alias: null,
+            args: null,
+            concreteType: 'ErrorType',
+            kind: 'LinkedField',
+            name: 'errors',
+            plural: true,
+            selections: [
+              {
+                alias: null,
+                args: null,
+                kind: 'ScalarField',
+                name: 'field',
+                storageKey: null,
+              },
+              {
+                alias: null,
+                args: null,
+                kind: 'ScalarField',
+                name: 'messages',
+                storageKey: null,
+              },
+            ],
+            storageKey: null,
+          },
+        ],
+        storageKey: null,
+      },
+    ]
+  return {
+    fragment: {
+      argumentDefinitions: v0 /*: any*/,
+      kind: 'Fragment',
+      metadata: null,
+      name: 'UnreadChatMutation',
+      selections: v1 /*: any*/,
+      type: 'Mutation',
+      abstractKey: null,
+    },
+    kind: 'Request',
+    operation: {
+      argumentDefinitions: v0 /*: any*/,
+      kind: 'Operation',
+      name: 'UnreadChatMutation',
+      selections: v1 /*: any*/,
+    },
+    params: {
+      cacheID: '4d9724bd26bcdedc2cc87395d6e1d138',
+      id: null,
+      metadata: {},
+      name: 'UnreadChatMutation',
+      operationKind: 'mutation',
+      text: 'mutation UnreadChatMutation(\n  $input: ChatRoomUnreadInput!\n) {\n  chatRoomUnread(input: $input) {\n    room {\n      id\n      unreadMessages {\n        count\n        markedUnread\n      }\n    }\n    errors {\n      field\n      messages\n    }\n  }\n}\n',
+    },
+  }
+})()
+
+;(node as any).hash = '82a5073d544e44997f36bec7b9547edc'
+
+export default node

--- a/packages/components/__generated__/chatRoomsPaginationQuery.graphql.ts
+++ b/packages/components/__generated__/chatRoomsPaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9fd5124757fb10a53e1f327d1d2797a3>>
+ * @generated SignedSource<<68537581179b1cf79986f2b2020e3f39>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -306,8 +306,26 @@ const node: ConcreteRequest = (function () {
                             {
                               alias: null,
                               args: null,
-                              kind: 'ScalarField',
-                              name: 'unreadMessagesCount',
+                              concreteType: 'UnreadMessages',
+                              kind: 'LinkedField',
+                              name: 'unreadMessages',
+                              plural: false,
+                              selections: [
+                                {
+                                  alias: null,
+                                  args: null,
+                                  kind: 'ScalarField',
+                                  name: 'count',
+                                  storageKey: null,
+                                },
+                                {
+                                  alias: null,
+                                  args: null,
+                                  kind: 'ScalarField',
+                                  name: 'markedUnread',
+                                  storageKey: null,
+                                },
+                              ],
                               storageKey: null,
                             },
                             {
@@ -538,12 +556,12 @@ const node: ConcreteRequest = (function () {
       ],
     },
     params: {
-      cacheID: '3eee045038f7ec74c5ae76014a54399b',
+      cacheID: '01ca33ade8d6eb39325613262fee400f',
       id: null,
       metadata: {},
       name: 'chatRoomsPaginationQuery',
       operationKind: 'query',
-      text: 'query chatRoomsPaginationQuery(\n  $archived: Boolean = false\n  $count: Int = 5\n  $cursor: String\n  $q: String = null\n  $unreadMessages: Boolean = false\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...RoomsListFragment_3I5PKK\n    id\n  }\n}\n\nfragment ChatRoomHeaderFragment on ChatRoom {\n  image(width: 100, height: 100) {\n    url\n  }\n  title\n  participants {\n    edges {\n      node {\n        profile {\n          id\n          name\n          image(width: 100, height: 100) {\n            url\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MessageItemFragment on Message {\n  id\n  content\n  created\n  extraData\n  inReplyTo {\n    id\n  }\n  isRead\n  pk\n  profile {\n    id\n  }\n  verb\n}\n\nfragment MessagesListFragment on ChatRoom {\n  id\n  participants {\n    totalCount\n  }\n  unreadMessagesCount\n  allMessages(first: 20) {\n    totalCount\n    edges {\n      node {\n        id\n        created\n        profile {\n          id\n          name\n          image(height: 32, width: 32) {\n            url\n          }\n        }\n        isRead\n        ...MessageItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment RoomFragment on ChatRoom {\n  id\n  unreadMessagesCount\n  lastMessageTime\n  lastMessage {\n    id\n    content\n  }\n  ...ChatRoomHeaderFragment\n  ...MessagesListFragment\n}\n\nfragment RoomsListFragment_3I5PKK on ChatRoomsInterface {\n  __isChatRoomsInterface: __typename\n  chatRooms(first: $count, after: $cursor, q: $q, unreadMessages: $unreadMessages, archived: $archived) {\n    edges {\n      node {\n        id\n        ...RoomFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n  id\n}\n',
+      text: 'query chatRoomsPaginationQuery(\n  $archived: Boolean = false\n  $count: Int = 5\n  $cursor: String\n  $q: String = null\n  $unreadMessages: Boolean = false\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...RoomsListFragment_3I5PKK\n    id\n  }\n}\n\nfragment ChatRoomHeaderFragment on ChatRoom {\n  image(width: 100, height: 100) {\n    url\n  }\n  title\n  participants {\n    edges {\n      node {\n        profile {\n          id\n          name\n          image(width: 100, height: 100) {\n            url\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MessageItemFragment on Message {\n  id\n  content\n  created\n  extraData\n  inReplyTo {\n    id\n  }\n  isRead\n  pk\n  profile {\n    id\n  }\n  verb\n}\n\nfragment MessagesListFragment on ChatRoom {\n  id\n  participants {\n    totalCount\n  }\n  unreadMessages {\n    count\n    markedUnread\n  }\n  allMessages(first: 20) {\n    totalCount\n    edges {\n      node {\n        id\n        created\n        profile {\n          id\n          name\n          image(height: 32, width: 32) {\n            url\n          }\n        }\n        isRead\n        ...MessageItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment RoomFragment on ChatRoom {\n  id\n  unreadMessages {\n    count\n    markedUnread\n  }\n  lastMessageTime\n  lastMessage {\n    id\n    content\n  }\n  ...ChatRoomHeaderFragment\n  ...MessagesListFragment\n}\n\nfragment RoomsListFragment_3I5PKK on ChatRoomsInterface {\n  __isChatRoomsInterface: __typename\n  chatRooms(first: $count, after: $cursor, q: $q, unreadMessages: $unreadMessages, archived: $archived) {\n    edges {\n      node {\n        id\n        ...RoomFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n  id\n}\n',
     },
   }
 })()

--- a/packages/components/__generated__/useMessageCountUpdateSubscription.graphql.ts
+++ b/packages/components/__generated__/useMessageCountUpdateSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f084cb14d72086688c6f9d22f5caaf82>>
+ * @generated SignedSource<<f2072ee2d74a13c850320cbc07ff184e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -43,7 +43,13 @@ export type useMessageCountUpdateSubscription$data = {
                                   | null
                                   | undefined
                                 readonly id: string
-                                readonly unreadMessagesCount: number | null | undefined
+                                readonly unreadMessages:
+                                  | {
+                                      readonly count: number | null | undefined
+                                      readonly markedUnread: boolean | null | undefined
+                                    }
+                                  | null
+                                  | undefined
                               }
                             | null
                             | undefined
@@ -84,14 +90,7 @@ const node: ConcreteRequest = (function () {
       name: 'id',
       storageKey: null,
     },
-    v2 = {
-      alias: null,
-      args: null,
-      kind: 'ScalarField',
-      name: 'unreadMessagesCount',
-      storageKey: null,
-    },
-    v3 = [
+    v2 = [
       {
         alias: null,
         args: [
@@ -115,7 +114,13 @@ const node: ConcreteRequest = (function () {
             plural: false,
             selections: [
               v1 /*: any*/,
-              v2 /*: any*/,
+              {
+                alias: null,
+                args: null,
+                kind: 'ScalarField',
+                name: 'unreadMessagesCount',
+                storageKey: null,
+              },
               {
                 alias: null,
                 args: null,
@@ -148,7 +153,31 @@ const node: ConcreteRequest = (function () {
                         plural: false,
                         selections: [
                           v1 /*: any*/,
-                          v2 /*: any*/,
+                          {
+                            alias: null,
+                            args: null,
+                            concreteType: 'UnreadMessages',
+                            kind: 'LinkedField',
+                            name: 'unreadMessages',
+                            plural: false,
+                            selections: [
+                              {
+                                alias: null,
+                                args: null,
+                                kind: 'ScalarField',
+                                name: 'count',
+                                storageKey: null,
+                              },
+                              {
+                                alias: null,
+                                args: null,
+                                kind: 'ScalarField',
+                                name: 'markedUnread',
+                                storageKey: null,
+                              },
+                            ],
+                            storageKey: null,
+                          },
                           {
                             alias: null,
                             args: null,
@@ -212,7 +241,7 @@ const node: ConcreteRequest = (function () {
       kind: 'Fragment',
       metadata: null,
       name: 'useMessageCountUpdateSubscription',
-      selections: v3 /*: any*/,
+      selections: v2 /*: any*/,
       type: 'Subscription',
       abstractKey: null,
     },
@@ -221,19 +250,19 @@ const node: ConcreteRequest = (function () {
       argumentDefinitions: v0 /*: any*/,
       kind: 'Operation',
       name: 'useMessageCountUpdateSubscription',
-      selections: v3 /*: any*/,
+      selections: v2 /*: any*/,
     },
     params: {
-      cacheID: '1eced1843420ed0b61b7d8845effc2ae',
+      cacheID: '14333857437b14661f927afc905ac42f',
       id: null,
       metadata: {},
       name: 'useMessageCountUpdateSubscription',
       operationKind: 'subscription',
-      text: 'subscription useMessageCountUpdateSubscription(\n  $profileId: ID!\n) {\n  chatRoomOnMessagesCountUpdate(profileId: $profileId) {\n    profile {\n      id\n      unreadMessagesCount\n      chatRooms {\n        totalCount\n        edges {\n          node {\n            id\n            unreadMessagesCount\n            allMessages {\n              edges {\n                node {\n                  id\n                  isRead\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n',
+      text: 'subscription useMessageCountUpdateSubscription(\n  $profileId: ID!\n) {\n  chatRoomOnMessagesCountUpdate(profileId: $profileId) {\n    profile {\n      id\n      unreadMessagesCount\n      chatRooms {\n        totalCount\n        edges {\n          node {\n            id\n            unreadMessages {\n              count\n              markedUnread\n            }\n            allMessages {\n              edges {\n                node {\n                  id\n                  isRead\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n',
     },
   }
 })()
 
-;(node as any).hash = '89bba0acb4fe5156ef22a5201005474a'
+;(node as any).hash = '732b81c0387021db798a893ce5a6c449'
 
 export default node

--- a/packages/components/__generated__/useRoomListSubscription.graphql.ts
+++ b/packages/components/__generated__/useRoomListSubscription.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c833eb324bb7b104f2c0d66b6a0b79f7>>
+ * @generated SignedSource<<087b933a84e193988f8e6fc01a359ed2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -206,8 +206,26 @@ const node: ConcreteRequest = (function () {
                     {
                       alias: null,
                       args: null,
-                      kind: 'ScalarField',
-                      name: 'unreadMessagesCount',
+                      concreteType: 'UnreadMessages',
+                      kind: 'LinkedField',
+                      name: 'unreadMessages',
+                      plural: false,
+                      selections: [
+                        {
+                          alias: null,
+                          args: null,
+                          kind: 'ScalarField',
+                          name: 'count',
+                          storageKey: null,
+                        },
+                        {
+                          alias: null,
+                          args: null,
+                          kind: 'ScalarField',
+                          name: 'markedUnread',
+                          storageKey: null,
+                        },
+                      ],
                       storageKey: null,
                     },
                     {
@@ -471,12 +489,12 @@ const node: ConcreteRequest = (function () {
       ],
     },
     params: {
-      cacheID: '6395f674791d79158f0e5c8c66608337',
+      cacheID: '950110109bb9b8a50fe13efe86c1b32e',
       id: null,
       metadata: {},
       name: 'useRoomListSubscription',
       operationKind: 'subscription',
-      text: 'subscription useRoomListSubscription(\n  $profileId: ID!\n) {\n  chatRoomOnRoomUpdate(profileId: $profileId) {\n    room {\n      node {\n        id\n        ...RoomFragment\n      }\n    }\n  }\n}\n\nfragment ChatRoomHeaderFragment on ChatRoom {\n  image(width: 100, height: 100) {\n    url\n  }\n  title\n  participants {\n    edges {\n      node {\n        profile {\n          id\n          name\n          image(width: 100, height: 100) {\n            url\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MessageItemFragment on Message {\n  id\n  content\n  created\n  extraData\n  inReplyTo {\n    id\n  }\n  isRead\n  pk\n  profile {\n    id\n  }\n  verb\n}\n\nfragment MessagesListFragment on ChatRoom {\n  id\n  participants {\n    totalCount\n  }\n  unreadMessagesCount\n  allMessages(first: 20) {\n    totalCount\n    edges {\n      node {\n        id\n        created\n        profile {\n          id\n          name\n          image(height: 32, width: 32) {\n            url\n          }\n        }\n        isRead\n        ...MessageItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment RoomFragment on ChatRoom {\n  id\n  unreadMessagesCount\n  lastMessageTime\n  lastMessage {\n    id\n    content\n  }\n  ...ChatRoomHeaderFragment\n  ...MessagesListFragment\n}\n',
+      text: 'subscription useRoomListSubscription(\n  $profileId: ID!\n) {\n  chatRoomOnRoomUpdate(profileId: $profileId) {\n    room {\n      node {\n        id\n        ...RoomFragment\n      }\n    }\n  }\n}\n\nfragment ChatRoomHeaderFragment on ChatRoom {\n  image(width: 100, height: 100) {\n    url\n  }\n  title\n  participants {\n    edges {\n      node {\n        profile {\n          id\n          name\n          image(width: 100, height: 100) {\n            url\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MessageItemFragment on Message {\n  id\n  content\n  created\n  extraData\n  inReplyTo {\n    id\n  }\n  isRead\n  pk\n  profile {\n    id\n  }\n  verb\n}\n\nfragment MessagesListFragment on ChatRoom {\n  id\n  participants {\n    totalCount\n  }\n  unreadMessages {\n    count\n    markedUnread\n  }\n  allMessages(first: 20) {\n    totalCount\n    edges {\n      node {\n        id\n        created\n        profile {\n          id\n          name\n          image(height: 32, width: 32) {\n            url\n          }\n        }\n        isRead\n        ...MessageItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment RoomFragment on ChatRoom {\n  id\n  unreadMessages {\n    count\n    markedUnread\n  }\n  lastMessageTime\n  lastMessage {\n    id\n    content\n  }\n  ...ChatRoomHeaderFragment\n  ...MessagesListFragment\n}\n',
     },
   }
 })()

--- a/packages/components/modules/messages/ChatRoomsList/ChatRoomItem/index.tsx
+++ b/packages/components/modules/messages/ChatRoomsList/ChatRoomItem/index.tsx
@@ -58,11 +58,11 @@ const ChatRoomItem: FC<ChatRoomItemProps> = ({
       variables: {
         input: {
           roomId: room.id,
-          profileId: profile?.id as string,
+          profileId: currentProfile?.id as string,
         },
       },
     })
-  }, [room.id, profile])
+  }, [room.id, currentProfile])
 
   const [commit, isMutationInFlight] = useArchiveChatRoomMutation()
 

--- a/packages/components/modules/messages/ChatRoomsList/ChatRoomItem/index.tsx
+++ b/packages/components/modules/messages/ChatRoomsList/ChatRoomItem/index.tsx
@@ -1,4 +1,4 @@
-import { FC, SyntheticEvent, useRef } from 'react'
+import { FC, SyntheticEvent, useCallback, useRef } from 'react'
 
 import { useCurrentProfile } from '@baseapp-frontend/authentication'
 import {
@@ -16,6 +16,7 @@ import { ChatRoomHeaderFragment$key } from '../../../../__generated__/ChatRoomHe
 import { RoomFragment$key } from '../../../../__generated__/RoomFragment.graphql'
 import ActionsOverlay from '../../../__shared__/ActionsOverlay'
 import { useArchiveChatRoomMutation } from '../../graphql/mutations/ArchiveChatRoom'
+import { useUnreadChatMutation } from '../../graphql/mutations/UnreadChat'
 import { ChatRoomHeaderFragment } from '../../graphql/queries/ChatRoomHeaderFragment'
 import { RoomFragment } from '../../graphql/queries/Room'
 import { useNameAndAvatar } from '../../utils'
@@ -33,6 +34,7 @@ const ChatRoomItem: FC<ChatRoomItemProps> = ({
   isInUnreadTab = false,
 }) => {
   const room = useFragment<RoomFragment$key>(RoomFragment, roomRef)
+  const [commitMutation] = useUnreadChatMutation()
 
   const handleCardClick = (event: SyntheticEvent) => {
     event.stopPropagation()
@@ -49,7 +51,18 @@ const ChatRoomItem: FC<ChatRoomItemProps> = ({
   const lastMessage = room.lastMessage?.content
   const { lastMessageTime } = room
 
-  const showBadge = room.unreadMessagesCount && room.unreadMessagesCount > 0
+  const hasUnreadMessages = room.unreadMessages?.markedUnread || !!room.unreadMessages?.count
+
+  const unreadChat = useCallback(() => {
+    commitMutation({
+      variables: {
+        input: {
+          roomId: room.id,
+          profileId: profile?.id as string,
+        },
+      },
+    })
+  }, [room.id, profile])
 
   const [commit, isMutationInFlight] = useArchiveChatRoomMutation()
 
@@ -93,11 +106,12 @@ const ChatRoomItem: FC<ChatRoomItemProps> = ({
           hasPermission: true,
         },
         {
-          disabled: false,
+          disabled: hasUnreadMessages,
           icon: <UnreadIcon />,
           label: 'Mark as Unread',
-          onClick: () => {},
+          onClick: unreadChat,
           hasPermission: true,
+          closeOnClick: true,
         },
       ]}
       enableDelete
@@ -153,10 +167,10 @@ const ChatRoomItem: FC<ChatRoomItemProps> = ({
         </Box>
         <Badge
           sx={{ marginRight: '12px', justifySelf: 'center', display: 'flex', alignItems: 'center' }}
-          badgeContent={room.unreadMessagesCount}
+          badgeContent={room.unreadMessages?.count || ''}
           color="error"
           max={99}
-          invisible={!showBadge}
+          invisible={!hasUnreadMessages}
           {...BadgeProps}
         />
       </StyledChatCard>

--- a/packages/components/modules/messages/graphql/mutations/UnreadChat.ts
+++ b/packages/components/modules/messages/graphql/mutations/UnreadChat.ts
@@ -2,18 +2,17 @@ import { useNotification } from '@baseapp-frontend/utils'
 
 import { Disposable, UseMutationConfig, graphql, useMutation } from 'react-relay'
 
-import { ReadMessagesMutation } from '../../../../__generated__/ReadMessagesMutation.graphql'
+import { UnreadChatMutation } from '../../../../__generated__/UnreadChatMutation.graphql'
 
-export const ReadMessagesMutationQuery = graphql`
-  mutation ReadMessagesMutation($input: ChatRoomReadMessagesInput!) {
-    chatRoomReadMessages(input: $input) {
+export const UnreadChatMutationQuery = graphql`
+  mutation UnreadChatMutation($input: ChatRoomUnreadInput!) {
+    chatRoomUnread(input: $input) {
       room {
         id
         unreadMessages {
           count
           markedUnread
         }
-        ...RoomFragment
       }
       errors {
         field
@@ -23,15 +22,15 @@ export const ReadMessagesMutationQuery = graphql`
   }
 `
 
-export const useReadMessageMutation = (): [
-  (config: UseMutationConfig<ReadMessagesMutation>) => Disposable,
+export const useUnreadChatMutation = (): [
+  (config: UseMutationConfig<UnreadChatMutation>) => Disposable,
   boolean,
 ] => {
   const { sendToast } = useNotification()
   const [commitMutation, isMutationInFlight] =
-    useMutation<ReadMessagesMutation>(ReadMessagesMutationQuery)
+    useMutation<UnreadChatMutation>(UnreadChatMutationQuery)
 
-  const commit = (config: UseMutationConfig<ReadMessagesMutation>) =>
+  const commit = (config: UseMutationConfig<UnreadChatMutation>) =>
     commitMutation({
       ...config,
       onCompleted: (response, errors) => {

--- a/packages/components/modules/messages/graphql/queries/MessagesList.ts
+++ b/packages/components/modules/messages/graphql/queries/MessagesList.ts
@@ -8,7 +8,10 @@ export const MessagesListFragment = graphql`
     participants {
       totalCount
     }
-    unreadMessagesCount
+    unreadMessages {
+      count
+      markedUnread
+    }
     allMessages(first: $count, after: $cursor) @connection(key: "chatRoom_allMessages") {
       totalCount
       edges {

--- a/packages/components/modules/messages/graphql/queries/Room.ts
+++ b/packages/components/modules/messages/graphql/queries/Room.ts
@@ -3,7 +3,10 @@ import { graphql } from 'react-relay'
 export const RoomFragment = graphql`
   fragment RoomFragment on ChatRoom {
     id
-    unreadMessagesCount
+    unreadMessages {
+      count
+      markedUnread
+    }
     lastMessageTime
     lastMessage {
       id

--- a/packages/components/modules/messages/graphql/subscriptions/useMessageCountUpdateSubscription.tsx
+++ b/packages/components/modules/messages/graphql/subscriptions/useMessageCountUpdateSubscription.tsx
@@ -15,7 +15,10 @@ const MessageCountUpdateSubscription = graphql`
           edges {
             node {
               id
-              unreadMessagesCount
+              unreadMessages {
+                count
+                markedUnread
+              }
               allMessages {
                 edges {
                   node {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/components/schema.graphql
+++ b/packages/components/schema.graphql
@@ -106,7 +106,7 @@ type ChatRoom implements Node {
   participants(offset: Int, before: String, after: String, first: Int, last: Int): ChatRoomParticipantConnection
   pk: Int!
   allMessages(offset: Int, before: String, after: String, first: Int, last: Int, verb: Verbs): MessageConnection
-  unreadMessagesCount(profileId: ID): Int
+  unreadMessages(profileId: ID): UnreadMessages
   isArchived(profileId: ID): Boolean
 }
 
@@ -249,6 +249,21 @@ interface ChatRoomsInterface {
     archived: Boolean
   ): ChatRoomConnection
   unreadMessagesCount: Int
+}
+
+input ChatRoomUnreadInput {
+  roomId: ID!
+  profileId: ID!
+  clientMutationId: String
+}
+
+type ChatRoomUnreadPayload {
+  """May contain more than one error for same field."""
+  errors: [ErrorType]
+  _debug: DjangoDebug
+  room: ChatRoom
+  profile: Profile
+  clientMutationId: String
 }
 
 type Comment implements Node & CommentsInterface & ReactionsInterface & PermissionsInterface & NodeActivityLogInterface {
@@ -630,6 +645,7 @@ type Mutation {
   chatRoomSendMessage(input: ChatRoomSendMessageInput!): ChatRoomSendMessagePayload
   chatRoomReadMessages(input: ChatRoomReadMessagesInput!): ChatRoomReadMessagesPayload
   chatRoomArchive(input: ChatRoomArchiveInput!): ChatRoomArchivePayload
+  chatRoomUnread(input: ChatRoomUnreadInput!): ChatRoomUnreadPayload
   reportCreate(input: ReportCreateInput!): ReportCreatePayload
   followToggle(input: FollowToggleInput!): FollowTogglePayload
   blockToggle(input: BlockToggleInput!): BlockTogglePayload
@@ -1575,6 +1591,11 @@ type Subscription {
   chatRoomOnMessagesCountUpdate(profileId: ID!): ChatRoomOnMessagesCountUpdate
   onNotificationChange: OnNotificationChange
   onCommentChange(targetObjectId: ID): OnCommentChange
+}
+
+type UnreadMessages {
+  count: Int
+  markedUnread: Boolean
 }
 
 type URLPath implements Node {


### PR DESCRIPTION
Acceptance Criteria 
Business Rules - Mark as Unread - 5 points

As a user, I want the option to mark a chat as unread from the overlay on a chat card, so that I can keep track of conversations that require follow-up or additional attention later.

When I hover over a chat card, the overlay displays a "Mark as Unread" button (eye), allowing me to mark the chat as unread without opening it.

When I mark a chat as unread, the chat card displays an unread indicator (red dot) to signal that the chat needs attention.

The notification dot should not show any number.

Whenever a user clicks on an unread chat, then the chat room should be unmarked.

If a new message comes in while the chat is markes as unread (with the empty red dot), it should update so that it shows the amount of new unread messages.

Implementation Strategy

We talked about having a manual unread field to handle the unread blank dot state. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new GraphQL mutation for marking chat rooms as unread.
	- Enhanced unread message handling in the ChatRoomItem component with improved visibility and action logic.

- **Bug Fixes**
	- Resolved issues with unread message count display and action enabling.

- **Documentation**
	- Updated changelog to reflect new features and changes in unread message handling.

- **Schema Updates**
	- Modified GraphQL schema to include a more detailed unread messages structure, replacing the previous count field with a more comprehensive object.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->