### PR TITLE
BA-fix: remove `getExpoConstant` from `preAuthenticateJWT`

### DIFF
--- a/packages/authentication/CHANGELOG.md
+++ b/packages/authentication/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/authentication
 
+## 4.1.1
+
+### Patch Changes
+
+- Remove `getExpoConstant` from `preAuthenticateJWT` since it is being used on the web app middleware.
+
 ## 4.1.0
 
 ### Minor Changes

--- a/packages/authentication/modules/access/preAuthenticateJWT/index.ts
+++ b/packages/authentication/modules/access/preAuthenticateJWT/index.ts
@@ -1,24 +1,23 @@
-import { getExpoConstant } from '@baseapp-frontend/utils'
 import type { JWTResponse } from '@baseapp-frontend/utils/types/jwt'
 
+/**
+ * This function is intended for web usage only
+ * because it relies on `NEXT_PUBLIC_API_BASE_URL`.
+ */
 const preAuthenticateJWT = async (token?: string) => {
   try {
     if (!token) {
       throw new Error('No token provided.')
     }
 
-    const EXPO_PUBLIC_API_BASE_URL = getExpoConstant('EXPO_PUBLIC_API_BASE_URL')
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL ?? EXPO_PUBLIC_API_BASE_URL}/auth/pre-auth/jwt`,
-      {
-        method: 'POST',
-        body: JSON.stringify({ token }),
-        cache: 'no-store',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/pre-auth/jwt`, {
+      method: 'POST',
+      body: JSON.stringify({ token }),
+      cache: 'no-store',
+      headers: {
+        'Content-Type': 'application/json',
       },
-    )
+    })
 
     if (response instanceof Response && !response.ok) {
       throw new Error('Failed to pre-authenticate.')

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/authentication",
   "description": "Authentication modules.",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/components
 
+## 0.0.45
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/authentication@4.1.1
+
 ## 0.0.44
 
 ### Patch Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
- `authentication` package update - `v 4.1.1`
  - Remove `getExpoConstant` from `preAuthenticateJWT` since it is being used on the web app middleware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v4.1.1

- **Package Updates**
  - Authentication package updated to version 4.1.1
  - Components package updated to version 0.0.45

- **Changes**
  - Removed `getExpoConstant` from `preAuthenticateJWT` function
  - Updated web authentication URL handling
  - Added clarification comment for web-only usage of authentication function

- **Dependency Updates**
  - Updated `@baseapp-frontend/authentication` dependency in components package

<!-- end of auto-generated comment: release notes by coderabbit.ai -->