### PR TITLE
BA-2070 Fix chatroom search

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/components
 
+## 0.0.48
+
+### Patch Changes
+
+- Chatroom search fixed
+
 ## 0.0.47
 
 ### Patch Changes

--- a/packages/components/modules/messages/ChatRoomsList/index.tsx
+++ b/packages/components/modules/messages/ChatRoomsList/index.tsx
@@ -40,18 +40,27 @@ const ChatRoomsList: FC<ChatRoomsListProps> = ({
 
   const isInUnreadTab = tab === CHAT_TAB_VALUES.unread
   const isInArchivedTab = tab === CHAT_TAB_VALUES.archived
+  const searchValue = watch('search')
 
   const handleSearchChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     const value = e.target.value || ''
     startTransition(() => {
-      refetch({ q: value })
+      refetch({
+        q: value,
+        unreadMessages: isInUnreadTab,
+        archived: isInArchivedTab,
+      })
     })
   }
 
   const handleSearchClear = () => {
     startTransition(() => {
       reset()
-      refetch({ q: '' })
+      refetch({
+        q: '',
+        unreadMessages: isInUnreadTab,
+        archived: isInArchivedTab,
+      })
     })
   }
 
@@ -60,6 +69,7 @@ const ChatRoomsList: FC<ChatRoomsListProps> = ({
     startRefetchTransition(() => {
       refetch(
         {
+          q: searchValue,
           unreadMessages: newTab === CHAT_TAB_VALUES.unread,
           archived: newTab === CHAT_TAB_VALUES.archived,
         },
@@ -119,7 +129,6 @@ const ChatRoomsList: FC<ChatRoomsListProps> = ({
 
   const renderListContent = () => {
     const emptyChatRoomsList = chatRooms.length === 0
-    const searchValue = watch('search')
 
     if (!isPending && searchValue && emptyChatRoomsList) return <SearchNotFoundState />
 
@@ -156,6 +165,11 @@ const ChatRoomsList: FC<ChatRoomsListProps> = ({
         }}
       >
         <Searchbar
+          key={
+            tab /* The handleSearchChange function depends on tab.
+            Searchbar calls useRef on the onChange function (to debounce),
+            hence it does not see the changes unless it is reloaded */
+          }
           name="search"
           control={control}
           onChange={handleSearchChange}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
**Description**

**Acceptance Criteria** 

- Given I am using the search bar to locate a chat room, when I type the complete name or a partial name of a chat room into the search bar, then the displayed list of chat rooms should dynamically update to show only those chat rooms whose names contain the entered text (case-insensitive match).

- And if no matching chat rooms are found, an appropriate "No results found" message should be displayed.

- It should filter the Chat List that is selected. 

**Current behavior** 
When I use the search bar in the Archive Chat list, is doesnt show chat rooms even tho they contain the entered text. It shows the empty state when no chat rooms were found.
This empty state persists even tho I clear the search bar.

[https://www.loom.com/share/7e249f5eb0ab4814a7c3544302b1f047](https://www.loom.com/share/7e249f5eb0ab4814a7c3544302b1f047) 

**Approvd** 
[https://app.approvd.io/silverlogic/BA/stories/38023](https://app.approvd.io/silverlogic/BA/stories/38023) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced search functionality in chat rooms list
  - Improved search context awareness across different tabs
  - Persistent search term when switching between tabs

- **Bug Fixes**
  - Resolved search input rendering issues during tab changes
  - Fixed chatroom search functionality in the latest version update (0.0.48)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->