### PR TITLE
BA-2081: chat rooms refetch issue

### DIFF
--- a/packages/components/schema.graphql
+++ b/packages/components/schema.graphql
@@ -154,9 +154,20 @@ type ChatRoomCreatePayload {
   clientMutationId: String
 }
 
-"""
-A Relay edge containing a `ChatRoom` and its cursor.
-"""
+input ChatRoomDeleteMessageInput {
+  id: ID!
+  clientMutationId: String
+}
+
+type ChatRoomDeleteMessagePayload {
+  """May contain more than one error for same field."""
+  errors: [ErrorType]
+  _debug: DjangoDebug
+  deletedMessage: MessageEdge
+  clientMutationId: String
+}
+
+"""A Relay edge containing a `ChatRoom` and its cursor."""
 type ChatRoomEdge {
   """The item at the end of the edge"""
   node: ChatRoom
@@ -190,7 +201,6 @@ type ChatRoomOnMessagesCountUpdate {
 type ChatRoomOnRoomUpdate {
   room: ChatRoomEdge
   removedParticipants: [ChatRoomParticipant]
-  addedParticipants: [ChatRoomParticipant]
 }
 
 type ChatRoomParticipant implements Node {
@@ -314,7 +324,6 @@ type ChatRoomUpdatePayload {
   _debug: DjangoDebug
   room: ChatRoomEdge
   removedParticipants: [ChatRoomParticipant]
-  addedParticipants: [ChatRoomParticipant]
   clientMutationId: String
 }
 

--- a/packages/components/schema.graphql
+++ b/packages/components/schema.graphql
@@ -154,20 +154,9 @@ type ChatRoomCreatePayload {
   clientMutationId: String
 }
 
-input ChatRoomDeleteMessageInput {
-  id: ID!
-  clientMutationId: String
-}
-
-type ChatRoomDeleteMessagePayload {
-  """May contain more than one error for same field."""
-  errors: [ErrorType]
-  _debug: DjangoDebug
-  deletedMessage: MessageEdge
-  clientMutationId: String
-}
-
-"""A Relay edge containing a `ChatRoom` and its cursor."""
+"""
+A Relay edge containing a `ChatRoom` and its cursor.
+"""
 type ChatRoomEdge {
   """The item at the end of the edge"""
   node: ChatRoom
@@ -201,6 +190,7 @@ type ChatRoomOnMessagesCountUpdate {
 type ChatRoomOnRoomUpdate {
   room: ChatRoomEdge
   removedParticipants: [ChatRoomParticipant]
+  addedParticipants: [ChatRoomParticipant]
 }
 
 type ChatRoomParticipant implements Node {
@@ -324,6 +314,7 @@ type ChatRoomUpdatePayload {
   _debug: DjangoDebug
   room: ChatRoomEdge
   removedParticipants: [ChatRoomParticipant]
+  addedParticipants: [ChatRoomParticipant]
   clientMutationId: String
 }
 


### PR DESCRIPTION
**Acceptance Criteria**
Given I have 10 chats in my active chat list, when I switch to another Chat List Tab and come back to the Active Chat list. I should still be able to see and access the 10 original chat rooms

https://www.loom.com/share/8714eef222ea48b193593d9f36b0496d?sid=a162b289-d22f-49c7-8dec-efd9240b755e 

**Approvd**
https://app.approvd.io/silverlogic/BA/stories/38025 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved issues with the chat rooms list not updating correctly during tab and search changes.
  
- **Refactor**
  - Streamlined rendering logic and improved the refresh strategy to ensure that the list displays up-to-date results and handles empty states more effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->