### PR TITLE
BA-2161 setFormApiErrors handles also Error objects

### DIFF
--- a/packages/authentication/CHANGELOG.md
+++ b/packages/authentication/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/authentication
 
+## 4.1.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/utils@3.1.4
+
 ## 4.1.4
 
 ### Patch Changes

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/authentication",
   "description": "Authentication modules.",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @baseapp-frontend/components
 
+## 1.0.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/utils@3.1.4
+  - @baseapp-frontend/authentication@4.1.5
+  - @baseapp-frontend/design-system@1.0.3
+  - @baseapp-frontend/graphql@1.2.5
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "sideEffects": false,
   "scripts": {
     "babel:bundle": "babel modules -d tmp-babel --extensions .ts,.tsx --ignore '**/__tests__/**','**/__storybook__/**'",

--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/design-system
 
+## 1.0.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/utils@3.1.4
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/design-system",
   "description": "Design System components and configurations.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "sideEffects": false,
   "scripts": {
     "tsup:bundle": "tsup --tsconfig tsconfig.build.json",

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/graphql
 
+## 1.2.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/utils@3.1.4
+
 ## 1.2.4
 
 ### Patch Changes

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/graphql",
   "description": "GraphQL configurations and utilities",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/provider/CHANGELOG.md
+++ b/packages/provider/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/provider
 
+## 2.0.11
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/utils@3.1.4
+
 ## 2.0.10
 
 ### Patch Changes

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/provider",
   "description": "Providers for React Query and Emotion.",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/utils
 
+## 3.1.4
+
+### Patch Changes
+
+- setFormApiErrors also handles Error objects
+
 ## 3.1.3
 
 ### Patch Changes

--- a/packages/utils/functions/api/getApiErrorMessage/__tests__/getApiErrorMessage.test.ts
+++ b/packages/utils/functions/api/getApiErrorMessage/__tests__/getApiErrorMessage.test.ts
@@ -34,7 +34,7 @@ describe('getApiErrorMessage', () => {
     expect(result).toBe('Detailed error message.')
   })
 
-  it('should return default message when error.message is invalid JSON', () => {
+  it('should return error message when error.message is invalid JSON', () => {
     const errorMessage = 'Invalid JSON string'
     const defaultMessage = 'Something went wrong.'
     const error = { message: errorMessage }

--- a/packages/utils/functions/api/getApiErrorMessage/index.ts
+++ b/packages/utils/functions/api/getApiErrorMessage/index.ts
@@ -9,7 +9,7 @@ export const getApiErrorMessage = (
   if (error?.message) {
     try {
       const parsedMessage = JSON.parse(error.message)
-      message = parsedMessage.detail || parsedMessage || message
+      message = parsedMessage.detail || error.message
     } catch {
       message = error.message
     }

--- a/packages/utils/functions/form/setFormApiErrors/__tests__/setFormApiErrors.test.ts
+++ b/packages/utils/functions/form/setFormApiErrors/__tests__/setFormApiErrors.test.ts
@@ -11,7 +11,9 @@ describe('setFormApiErrors', () => {
           ({
             name: 'John',
             age: 20,
-          }[fieldKey]),
+            bio: '',
+            image: null,
+          })[fieldKey],
       ),
       setError: jest.fn(),
     }
@@ -73,6 +75,42 @@ describe('setFormApiErrors', () => {
     expect(mockForm.setError).not.toHaveBeenCalledWith('address', {
       type: 'manual',
       message: 'Address is required',
+    })
+  })
+
+  it('should set errors for null or blank fields', () => {
+    mockError.response.data = {
+      image: ['Image is required'],
+      bio: ['Bio may not be blank'],
+    }
+    setFormApiErrors(mockForm, mockError)
+
+    expect(mockForm.setError).toHaveBeenCalledWith('image', {
+      type: 'manual',
+      message: 'Image is required',
+    })
+    expect(mockForm.setError).toHaveBeenCalledWith('bio', {
+      type: 'manual',
+      message: 'Bio may not be blank',
+    })
+  })
+
+  it('should also handle Error objects', () => {
+    mockError = new Error(
+      JSON.stringify({
+        name: ['Name is required'],
+        age: ['Age should be a number'],
+      }),
+    )
+    setFormApiErrors(mockForm, mockError)
+
+    expect(mockForm.setError).toHaveBeenCalledWith('name', {
+      type: 'manual',
+      message: 'Name is required',
+    })
+    expect(mockForm.setError).toHaveBeenCalledWith('age', {
+      type: 'manual',
+      message: 'Age should be a number',
     })
   })
 })

--- a/packages/utils/functions/form/setFormApiErrors/index.ts
+++ b/packages/utils/functions/form/setFormApiErrors/index.ts
@@ -11,11 +11,22 @@ export const setFormApiErrors = <
   form: UseFormReturn<TFieldValues, TContext, TTransformedValues>,
   err: any,
 ) => {
+  let errorObject
   if (err.response?.data && typeof err.response.data === 'object') {
-    map(entries(err.response.data), ([key, errors]) => {
+    errorObject = err.response?.data
+  } else if (err.message) {
+    try {
+      errorObject = JSON.parse(err.message)
+    } catch (parsingError) {
+      // Error message is not a JSON object, no further action taken
+    }
+  }
+
+  if (errorObject) {
+    map(entries(errorObject), ([key, errors]) => {
       const fieldKey = key as Path<TFieldValues>
       const errorMessage = head(errors as string[])
-      if (!!form.getValues(fieldKey) && typeof errorMessage === 'string') {
+      if (form.getValues(fieldKey) !== undefined && typeof errorMessage === 'string') {
         form.setError(fieldKey, { type: 'manual', message: errorMessage })
       }
     })

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/utils",
   "description": "Util functions, constants and types.",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/wagtail/CHANGELOG.md
+++ b/packages/wagtail/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @baseapp-frontend/wagtail
 
+## 1.0.21
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/utils@3.1.4
+  - @baseapp-frontend/design-system@1.0.3
+  - @baseapp-frontend/graphql@1.2.5
+
 ## 1.0.20
 
 ### Patch Changes

--- a/packages/wagtail/package.json
+++ b/packages/wagtail/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/wagtail",
   "description": "BaseApp Wagtail",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
This fixes the first objective below by making sure that `setFormApiErrors` can also handle `Error` objects (obtained by calling `new Error(message)`). I could not reproduce the second problem.

**Testing**
Use the frontend template from the master branch and the package from this PR. Then replace packages and follow the usual workflow. Run the backend from the master branch.

**Description**

**Acceptance Criteria** 
When registering with the existing email, it send me to code screen instead of showing warning of existing email. 

- The error should show in the UI

- I should not be able to the "Enter Code" screen if there is an error during the sign up form.

**Video**: [https://www.loom.com/share/dcee5d9752334d379ee0d191576da364?sid=109e6385-c05e-44a1-8682-557ee8f52c6a](https://www.loom.com/share/dcee5d9752334d379ee0d191576da364?sid=109e6385-c05e-44a1-8682-557ee8f52c6a)
Bug catcher: Selim Reza 

**Approvd** 
[https://app.approvd.io/silverlogic/BA/stories/38225](https://app.approvd.io/silverlogic/BA/stories/38225)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Dependency Updates**
  - Updated `@baseapp-frontend/utils` to version 3.1.3 across multiple packages
  - Updated `@baseapp-frontend/authentication` to version 4.1.5
  - Updated `@baseapp-frontend/components` to version 0.0.55
  - Updated `@baseapp-frontend/design-system` to version 0.0.34
  - Updated `@baseapp-frontend/graphql` to version 1.2.4
  - Updated `@baseapp-frontend/provider` to version 2.0.10
  - Updated `@baseapp-frontend/wagtail` to version 1.0.19

- **Improvements**
  - Enhanced error handling in utility functions, specifically `setFormApiErrors` and `getApiErrorMessage`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->