### PR TITLE
BA-2211: delete chat messages

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/components
 
+## 1.0.9
+
+### Patch Changes
+
+- Enabled deletion of chat room messages
+
 ## 1.0.8
 
 ### Patch Changes

--- a/packages/components/modules/__shared__/web/ActionsOverlay/DefaultHoverOverlay/index.tsx
+++ b/packages/components/modules/__shared__/web/ActionsOverlay/DefaultHoverOverlay/index.tsx
@@ -9,8 +9,9 @@ import { DefaultHoverOverlayProps } from './types'
 const DefaultHoverOverlay: FC<DefaultHoverOverlayProps> = ({
   offsetRight,
   offsetTop,
-  enableDelete,
+  showDeleteButton,
   isDeletingItem,
+  disableDeleteButton,
   handleDeleteDialogOpen,
   actions = [],
   handleLongPressItemOptionsClose,
@@ -20,10 +21,10 @@ const DefaultHoverOverlay: FC<DefaultHoverOverlayProps> = ({
     offsetTop={offsetTop}
     aria-label="actions overlay"
   >
-    {enableDelete && (
+    {showDeleteButton && (
       <IconButton
         onClick={handleDeleteDialogOpen}
-        disabled={isDeletingItem}
+        disabled={isDeletingItem || disableDeleteButton}
         aria-label="delete item"
       >
         <TrashCanIcon />

--- a/packages/components/modules/__shared__/web/ActionsOverlay/DefaultHoverOverlay/types.ts
+++ b/packages/components/modules/__shared__/web/ActionsOverlay/DefaultHoverOverlay/types.ts
@@ -3,7 +3,12 @@ import { ActionOverlayProps } from '../types'
 export interface DefaultHoverOverlayProps
   extends Pick<
     ActionOverlayProps,
-    'actions' | 'offsetRight' | 'offsetTop' | 'enableDelete' | 'isDeletingItem'
+    | 'actions'
+    | 'offsetRight'
+    | 'offsetTop'
+    | 'showDeleteButton'
+    | 'isDeletingItem'
+    | 'disableDeleteButton'
   > {
   handleDeleteDialogOpen: () => void
   handleLongPressItemOptionsClose: () => void

--- a/packages/components/modules/__shared__/web/ActionsOverlay/ThreeDotsMenuHoverOverlay/index.tsx
+++ b/packages/components/modules/__shared__/web/ActionsOverlay/ThreeDotsMenuHoverOverlay/index.tsx
@@ -12,8 +12,9 @@ import { ThreeDotsMenuHoverOverlayProps } from './types'
 const ThreeDotsMenuHoverOverlay: FC<ThreeDotsMenuHoverOverlayProps> = ({
   offsetRight,
   offsetTop,
-  enableDelete,
+  showDeleteButton,
   isDeletingItem,
+  disableDeleteButton,
   handleDeleteDialogOpen,
   actions = [],
   handleClosePopover,
@@ -54,10 +55,17 @@ const ThreeDotsMenuHoverOverlay: FC<ThreeDotsMenuHoverOverlayProps> = ({
             </MenuItem>
           )
         })}
-        {enableDelete && (
-          <MenuItem onClick={handleDeleteDialogOpen} disabled={isDeletingItem}>
-            <TrashCanIcon />
-            <Typography variant="body2" color="error">
+        {showDeleteButton && (
+          <MenuItem
+            onClick={handleDeleteDialogOpen}
+            disabled={isDeletingItem || disableDeleteButton}
+            color="disabled"
+          >
+            <TrashCanIcon sx={{ color: disableDeleteButton ? 'text.disabled' : 'error.main' }} />
+            <Typography
+              variant="body2"
+              color={disableDeleteButton ? 'text.disabled' : 'error.main'}
+            >
               Delete
             </Typography>
           </MenuItem>

--- a/packages/components/modules/__shared__/web/ActionsOverlay/ThreeDotsMenuHoverOverlay/types.ts
+++ b/packages/components/modules/__shared__/web/ActionsOverlay/ThreeDotsMenuHoverOverlay/types.ts
@@ -5,7 +5,12 @@ import { ActionOverlayProps } from '../types'
 export interface ThreeDotsMenuHoverOverlayProps
   extends Pick<
     ActionOverlayProps,
-    'actions' | 'offsetRight' | 'offsetTop' | 'enableDelete' | 'isDeletingItem'
+    | 'actions'
+    | 'offsetRight'
+    | 'offsetTop'
+    | 'showDeleteButton'
+    | 'isDeletingItem'
+    | 'disableDeleteButton'
   > {
   handleDeleteDialogOpen: () => void
   handleClosePopover: () => void

--- a/packages/components/modules/__shared__/web/ActionsOverlay/__storybook__/ActionsOverlay.mdx
+++ b/packages/components/modules/__shared__/web/ActionsOverlay/__storybook__/ActionsOverlay.mdx
@@ -19,9 +19,10 @@ import { Meta } from '@storybook/addon-docs'
 - **actions** (OverlayAction[]): The list of actions desired for the child component. Note that to implement a delete action, the component provides a enabler, loading and click handler props specifically for that action (see props below).
 - **title** (string): Title for the child component (currently only used on the delete dialog).
 - **children** (ReactNode): The child component to be wrapped.
-- **enableDelete** (boolean): Enables the delete action inside the tooltip/swippable drawer.
+- **showDeleteButton** (boolean): Renders the delete action inside the tooltip/swippable drawer.
 - **isDeletingItem** (boolean): Mutation loading state for the delete action.
 - **handleDeleteItem** (function): Callback function to handle deletion.
+- **disableDeleteButton** (function): Disables the delete button.
 - **offsetTop** (number): Number to offset the top positioning of the default tooltip position (only affects tooltip).
 - **offsetRight** (number): Number to offset the right positioning of the default tooltip position (only affects tooltip).
 - **ContainerProps** (BoxProps): Props for the parent `Box` component that wraps the child component.
@@ -45,7 +46,7 @@ export const DefaultActionsOverlay = (
   return (
     <ActionsOverlay
       title='Button',
-      enableDelete={true}
+      showDeleteButton={true}
       handleDeleteItem={() => {}}
       actions={[
         {

--- a/packages/components/modules/__shared__/web/ActionsOverlay/__storybook__/stories.tsx
+++ b/packages/components/modules/__shared__/web/ActionsOverlay/__storybook__/stories.tsx
@@ -19,7 +19,7 @@ export const DefaultActionsOverlay: Story = {
   name: 'ActionsOverlay',
   args: {
     title: 'Button',
-    enableDelete: true,
+    showDeleteButton: true,
     handleDeleteItem: () => {},
     offsetRight: 0,
     offsetTop: 0,
@@ -42,7 +42,7 @@ export const ActionsOverlayWithThreeDotsMenu: Story = {
   name: 'ActionsOverlay with ThreeDotsMenu',
   args: {
     title: 'Button',
-    enableDelete: true,
+    showDeleteButton: true,
     isDeletingItem: false,
     handleDeleteItem: () => {},
     ContainerProps: {

--- a/packages/components/modules/__shared__/web/ActionsOverlay/index.tsx
+++ b/packages/components/modules/__shared__/web/ActionsOverlay/index.tsx
@@ -22,13 +22,15 @@ const ActionsOverlay = forwardRef<HTMLDivElement, ActionOverlayProps>(
       actions = [],
       children,
       title = 'Item',
-      enableDelete = false,
+      showDeleteButton = false,
       isDeletingItem = false,
+      disableDeleteButton = false,
       handleDeleteItem = () => {},
       offsetTop = 0,
       offsetRight = 0,
       ContainerProps = {},
       SwipeableDrawerProps = {},
+      DeleteDialogProps = {},
       SwipeableDrawer = DefaultSwipeableDrawer,
       hoverOverlayMode = HOVER_OVERLAY_MODES.default,
     },
@@ -110,6 +112,7 @@ const ActionsOverlay = forwardRef<HTMLDivElement, ActionOverlayProps>(
         }
         onClose={handleDeleteDialogClose}
         open={isDeleteDialogOpen}
+        {...DeleteDialogProps}
       />
     )
 
@@ -128,7 +131,7 @@ const ActionsOverlay = forwardRef<HTMLDivElement, ActionOverlayProps>(
             aria-label="actions overlay"
             {...SwipeableDrawerProps}
           >
-            <Box display="grid" gridTemplateColumns="1fr" justifySelf="start" gap={1}>
+            <Box display="grid" gridTemplateColumns="1fr" justifySelf="start" gap={1} width="100%">
               {actions?.map(({ label, icon, onClick, disabled, hasPermission, closeOnClick }) => {
                 if (!hasPermission) return null
 
@@ -158,12 +161,12 @@ const ActionsOverlay = forwardRef<HTMLDivElement, ActionOverlayProps>(
                   </IconButton>
                 )
               })}
-              {enableDelete && (
+              {showDeleteButton && (
                 <>
                   <Divider />
                   <IconButton
                     onClick={handleDeleteDialogOpen}
-                    disabled={isDeletingItem}
+                    disabled={isDeletingItem || disableDeleteButton}
                     sx={{ width: 'fit-content' }}
                     aria-label="delete item"
                   >
@@ -171,9 +174,7 @@ const ActionsOverlay = forwardRef<HTMLDivElement, ActionOverlayProps>(
                       <Box display="grid" justifySelf="center" height="min-content">
                         <TrashCanIcon />
                       </Box>
-                      <Typography variant="body2" color="error.main">
-                        {`Delete ${title}`}
-                      </Typography>
+                      <Typography variant="body2">Delete</Typography>
                     </IconButtonContentContainer>
                   </IconButton>
                 </>
@@ -190,8 +191,9 @@ const ActionsOverlay = forwardRef<HTMLDivElement, ActionOverlayProps>(
               {...{
                 offsetRight,
                 offsetTop,
-                enableDelete,
+                showDeleteButton,
                 isDeletingItem,
+                disableDeleteButton,
                 handleDeleteDialogOpen,
                 actions,
                 handleLongPressItemOptionsClose,
@@ -206,8 +208,9 @@ const ActionsOverlay = forwardRef<HTMLDivElement, ActionOverlayProps>(
               {...{
                 offsetRight,
                 offsetTop,
-                enableDelete,
+                showDeleteButton,
                 isDeletingItem,
+                disableDeleteButton,
                 handleDeleteDialogOpen,
                 actions,
                 handleClosePopover,

--- a/packages/components/modules/__shared__/web/ActionsOverlay/index.tsx
+++ b/packages/components/modules/__shared__/web/ActionsOverlay/index.tsx
@@ -172,9 +172,16 @@ const ActionsOverlay = forwardRef<HTMLDivElement, ActionOverlayProps>(
                   >
                     <IconButtonContentContainer>
                       <Box display="grid" justifySelf="center" height="min-content">
-                        <TrashCanIcon />
+                        <TrashCanIcon
+                          sx={{ color: disableDeleteButton ? 'text.disabled' : 'error.main' }}
+                        />
                       </Box>
-                      <Typography variant="body2">Delete</Typography>
+                      <Typography
+                        variant="body2"
+                        color={disableDeleteButton ? 'text.disabled' : 'error.main'}
+                      >
+                        Delete
+                      </Typography>
                     </IconButtonContentContainer>
                   </IconButton>
                 </>

--- a/packages/components/modules/__shared__/web/ActionsOverlay/types.ts
+++ b/packages/components/modules/__shared__/web/ActionsOverlay/types.ts
@@ -1,6 +1,7 @@
 import { FC } from 'react'
 
-import type { SwipeableDrawerProps } from '@baseapp-frontend/design-system/components/web/drawers'
+import { ConfirmDialogProps } from '@baseapp-frontend/design-system/components/web/dialogs'
+import { SwipeableDrawerProps } from '@baseapp-frontend/design-system/components/web/drawers'
 import { ValueOf } from '@baseapp-frontend/utils'
 
 import { BoxProps } from '@mui/material'
@@ -24,10 +25,12 @@ export type LongPressHandler = {
 export interface ActionOverlayProps extends ActionOverlayTooltipContainerProps {
   actions: OverlayAction[]
   title: string
-  enableDelete?: boolean | null
+  showDeleteButton?: boolean | null
   isDeletingItem?: boolean
+  disableDeleteButton?: boolean
   handleDeleteItem?: () => void
   ContainerProps?: Partial<BoxProps>
+  DeleteDialogProps?: Partial<ConfirmDialogProps>
   SwipeableDrawer?: FC<SwipeableDrawerProps>
   SwipeableDrawerProps?: Partial<SwipeableDrawerProps>
   hoverOverlayMode?: ValueOf<typeof HOVER_OVERLAY_MODES>

--- a/packages/components/modules/comments/web/CommentItem/index.tsx
+++ b/packages/components/modules/comments/web/CommentItem/index.tsx
@@ -127,7 +127,7 @@ const CommentItem: FC<CommentItemProps> = ({
       <CommentContainerWrapper currentThreadDepth={currentThreadDepth}>
         <ActionsOverlay
           actions={actions}
-          enableDelete={enableDelete && comment.canDelete}
+          showDeleteButton={enableDelete && comment.canDelete}
           handleDeleteItem={handleDeleteComment}
           isDeletingItem={isDeletingComment}
           title="Comment"

--- a/packages/components/modules/messages/common/graphql/fragments/MessageItem.ts
+++ b/packages/components/modules/messages/common/graphql/fragments/MessageItem.ts
@@ -5,6 +5,7 @@ export const MessageItemFragment = graphql`
     id
     content
     created
+    deleted
     extraData
     inReplyTo {
       id

--- a/packages/components/modules/messages/common/graphql/mutations/MessageDelete.ts
+++ b/packages/components/modules/messages/common/graphql/mutations/MessageDelete.ts
@@ -1,0 +1,50 @@
+import { useNotification } from '@baseapp-frontend/utils'
+
+import { Disposable, UseMutationConfig, graphql, useMutation } from 'react-relay'
+
+import { MessageDeleteMutation } from '../../../../../__generated__/MessageDeleteMutation.graphql'
+
+export const MessageDeleteMutationQuery = graphql`
+  mutation MessageDeleteMutation($input: ChatRoomDeleteMessageInput!) {
+    chatRoomDeleteMessage(input: $input) {
+      deletedMessage {
+        node {
+          id
+          ...MessageItemFragment
+        }
+      }
+      errors {
+        field
+        messages
+      }
+    }
+  }
+`
+
+export const useMessageDeleteMutation = (): [
+  (config: UseMutationConfig<MessageDeleteMutation>) => Disposable,
+  boolean,
+] => {
+  const { sendToast } = useNotification()
+  const [commitMutation, isMutationInFlight] = useMutation<MessageDeleteMutation>(
+    MessageDeleteMutationQuery,
+  )
+
+  const commit = (config: UseMutationConfig<MessageDeleteMutation>) =>
+    commitMutation({
+      ...config,
+      onCompleted: (response, errors) => {
+        errors?.forEach((error) => {
+          sendToast(error.message, { type: 'error' })
+        })
+
+        config?.onCompleted?.(response, errors)
+      },
+      onError: (error) => {
+        sendToast(error.message, { type: 'error' })
+        config?.onError?.(error)
+      },
+    })
+
+  return [commit, isMutationInFlight]
+}

--- a/packages/components/modules/messages/common/graphql/subscriptions/useMessagesListSubscription.tsx
+++ b/packages/components/modules/messages/common/graphql/subscriptions/useMessagesListSubscription.tsx
@@ -4,7 +4,7 @@ import { ConnectionHandler, graphql, useSubscription } from 'react-relay'
 
 export const newMessageSubscription = graphql`
   subscription useMessagesListSubscription($roomId: ID!, $connections: [ID!]!) {
-    chatRoomOnNewMessage(roomId: $roomId) {
+    chatRoomOnMessage(roomId: $roomId) {
       message @prependEdge(connections: $connections) {
         node {
           ...MessageItemFragment

--- a/packages/components/modules/messages/common/index.ts
+++ b/packages/components/modules/messages/common/index.ts
@@ -7,6 +7,8 @@ export { default as withChatRoomProvider } from './context/withChatRoomProvider'
 
 export * from './graphql/mutations/ArchiveChatRoom'
 export * from './graphql/mutations/CreateChatRoom'
+export * from './graphql/mutations/MessageDelete'
+export * from './graphql/mutations/MessageUpdate'
 export * from './graphql/mutations/ReadMessages'
 export * from './graphql/mutations/SendMessage'
 export * from './graphql/mutations/UnreadChat'

--- a/packages/components/modules/messages/web/ChatRoomsList/ChatRoomItem/index.tsx
+++ b/packages/components/modules/messages/web/ChatRoomsList/ChatRoomItem/index.tsx
@@ -107,7 +107,7 @@ const ChatRoomItem: FC<ChatRoomItemProps> = ({
           closeOnClick: true,
         },
       ]}
-      enableDelete
+      showDeleteButton
       handleDeleteItem={() => {}}
       isDeletingItem={false}
       ref={chatCardRef}

--- a/packages/components/modules/messages/web/MessagesList/MessagesGroup/SystemMessage/styled.tsx
+++ b/packages/components/modules/messages/web/MessagesList/MessagesGroup/SystemMessage/styled.tsx
@@ -3,7 +3,7 @@ import { Typography, styled } from '@mui/material'
 export const SystemMessageTypography = styled(Typography)(({ theme }) => ({
   alignSelf: 'center',
   backgroundColor: theme.palette.grey[300],
-  borderRadius: theme.spacing(1),
+  borderRadius: theme.spacing(0.5),
   marginBottom: theme.spacing(1),
   marginTop: theme.spacing(2),
   padding: theme.spacing(0.5, 1),

--- a/packages/components/modules/messages/web/MessagesList/MessagesGroup/UserMessage/MessageItem/index.tsx
+++ b/packages/components/modules/messages/web/MessagesList/MessagesGroup/UserMessage/MessageItem/index.tsx
@@ -2,6 +2,7 @@ import { FC, useRef, useState } from 'react'
 
 import { useCurrentProfile } from '@baseapp-frontend/authentication'
 import {
+  BlockIcon,
   CopyIcon,
   DownloadIcon,
   PenEditIcon,
@@ -13,28 +14,63 @@ import { useFragment } from 'react-relay'
 
 import { ActionsOverlay, HOVER_OVERLAY_MODES } from '../../../../../../__shared__/web'
 import { MessageItemFragment } from '../../../../../common'
+import { useMessageDeleteMutation } from '../../../../../common/graphql/mutations/MessageDelete'
 import MessageUpdate from '../../../../MessageUpdate'
 import { MessageItemContainer } from './styled'
 import { MessageItemProps } from './types'
 
-const MessageItem: FC<MessageItemProps> = ({ messageRef, isFirstGroupedMessage }) => {
+const MessageItem: FC<MessageItemProps> = ({
+  messageRef,
+  isFirstGroupedMessage,
+  isGroup = false,
+}) => {
   const { currentProfile } = useCurrentProfile()
   const message = useFragment(MessageItemFragment, messageRef)
   const isOwnMessage = currentProfile?.id === message?.profile?.id
+  const deletedMessage = message?.deleted
   const messageCardRef = useRef<HTMLDivElement>(null)
   const { sendToast } = useNotification()
 
   const [isEditMode, setIsEditMode] = useState(false)
+
+  const [commitUpdate, isMutationInFlight] = useMessageDeleteMutation()
+
+  const onDeleteClick = async () => {
+    if (isMutationInFlight) return
+
+    commitUpdate({
+      variables: {
+        input: {
+          id: message.id,
+        },
+      },
+      onCompleted: (response, errors) => {
+        if (!errors) {
+          sendToast('Your message was deleted', { type: 'error' })
+        }
+      },
+    })
+  }
+
+  const deleteDialogContent = isGroup
+    ? 'The message will be deleted for everyone in this chat.'
+    : 'The message will be deleted for both you and the other person.'
 
   const renderMessageContent = () => {
     if (isEditMode) {
       return <MessageUpdate message={message} onCancel={() => setIsEditMode(false)} />
     }
 
+    let messageColor = isOwnMessage ? 'text.primary' : 'primary.contrastText'
+
+    if (deletedMessage) {
+      messageColor = 'text.disabled'
+    }
+
     return (
       <Typography
         variant="body2"
-        color={isOwnMessage ? 'text.primary' : 'primary.contrastText'}
+        color={messageColor}
         sx={{
           maxWidth: '100%',
           whiteSpace: 'pre-wrap',
@@ -42,6 +78,8 @@ const MessageItem: FC<MessageItemProps> = ({ messageRef, isFirstGroupedMessage }
           overflowWrap: 'anywhere',
         }}
       >
+        {deletedMessage && <BlockIcon sx={{ fontSize: '20px', color: 'grey.500' }} />}
+        {deletedMessage && ' '}
         {message?.content}
       </Typography>
     )
@@ -62,7 +100,7 @@ const MessageItem: FC<MessageItemProps> = ({ messageRef, isFirstGroupedMessage }
           hasPermission: true,
         },
         {
-          disabled: false,
+          disabled: deletedMessage || !isOwnMessage,
           icon: <PenEditIcon />,
           label: 'Edit',
           onClick: () => {
@@ -80,9 +118,13 @@ const MessageItem: FC<MessageItemProps> = ({ messageRef, isFirstGroupedMessage }
         },
       ]}
       hoverOverlayMode={HOVER_OVERLAY_MODES.threeDotsMenu}
-      enableDelete
-      handleDeleteItem={() => {}} // TODO: Implement delete message
-      isDeletingItem={false}
+      showDeleteButton
+      handleDeleteItem={() => onDeleteClick()}
+      isDeletingItem={isMutationInFlight}
+      disableDeleteButton={!isOwnMessage || deletedMessage}
+      DeleteDialogProps={{
+        content: `Are you sure you want to delete this message? ${deleteDialogContent}`,
+      }}
       ContainerProps={{
         flexDirection: isOwnMessage ? 'row' : 'row-reverse',
       }}

--- a/packages/components/modules/messages/web/MessagesList/MessagesGroup/UserMessage/MessageItem/types.ts
+++ b/packages/components/modules/messages/web/MessagesList/MessagesGroup/UserMessage/MessageItem/types.ts
@@ -5,6 +5,7 @@ import { MessageItemFragment$key } from '../../../../../../../__generated__/Mess
 export interface MessageItemProps {
   messageRef: MessageItemFragment$key
   isFirstGroupedMessage?: boolean
+  isGroup?: boolean
 }
 
 export interface MessageItemContainerProps extends BoxProps {

--- a/packages/components/modules/messages/web/MessagesList/MessagesGroup/UserMessage/index.tsx
+++ b/packages/components/modules/messages/web/MessagesList/MessagesGroup/UserMessage/index.tsx
@@ -97,6 +97,7 @@ const UserMessage: FC<UserMessageProps> = ({
         )}
         <MessageItem
           messageRef={message}
+          isGroup={isGroup}
           isFirstGroupedMessage={isFirstGroupedMessage}
           {...MessageItemProps}
         />

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "sideEffects": false,
   "scripts": {
     "babel:transpile": "babel modules -d tmp-babel --extensions .ts,.tsx --ignore '**/__tests__/**','**/__storybook__/**'",

--- a/packages/components/schema.graphql
+++ b/packages/components/schema.graphql
@@ -154,9 +154,20 @@ type ChatRoomCreatePayload {
   clientMutationId: String
 }
 
-"""
-A Relay edge containing a `ChatRoom` and its cursor.
-"""
+input ChatRoomDeleteMessageInput {
+  id: ID!
+  clientMutationId: String
+}
+
+type ChatRoomDeleteMessagePayload {
+  """May contain more than one error for same field."""
+  errors: [ErrorType]
+  _debug: DjangoDebug
+  deletedMessage: MessageEdge
+  clientMutationId: String
+}
+
+"""A Relay edge containing a `ChatRoom` and its cursor."""
 type ChatRoomEdge {
   """The item at the end of the edge"""
   node: ChatRoom
@@ -190,7 +201,6 @@ type ChatRoomOnMessagesCountUpdate {
 type ChatRoomOnRoomUpdate {
   room: ChatRoomEdge
   removedParticipants: [ChatRoomParticipant]
-  addedParticipants: [ChatRoomParticipant]
 }
 
 type ChatRoomParticipant implements Node {
@@ -314,7 +324,6 @@ type ChatRoomUpdatePayload {
   _debug: DjangoDebug
   room: ChatRoomEdge
   removedParticipants: [ChatRoomParticipant]
-  addedParticipants: [ChatRoomParticipant]
   clientMutationId: String
 }
 

--- a/packages/components/schema.graphql
+++ b/packages/components/schema.graphql
@@ -154,20 +154,9 @@ type ChatRoomCreatePayload {
   clientMutationId: String
 }
 
-input ChatRoomDeleteMessageInput {
-  id: ID!
-  clientMutationId: String
-}
-
-type ChatRoomDeleteMessagePayload {
-  """May contain more than one error for same field."""
-  errors: [ErrorType]
-  _debug: DjangoDebug
-  deletedMessage: MessageEdge
-  clientMutationId: String
-}
-
-"""A Relay edge containing a `ChatRoom` and its cursor."""
+"""
+A Relay edge containing a `ChatRoom` and its cursor.
+"""
 type ChatRoomEdge {
   """The item at the end of the edge"""
   node: ChatRoom
@@ -201,6 +190,7 @@ type ChatRoomOnMessagesCountUpdate {
 type ChatRoomOnRoomUpdate {
   room: ChatRoomEdge
   removedParticipants: [ChatRoomParticipant]
+  addedParticipants: [ChatRoomParticipant]
 }
 
 type ChatRoomParticipant implements Node {
@@ -324,6 +314,7 @@ type ChatRoomUpdatePayload {
   _debug: DjangoDebug
   room: ChatRoomEdge
   removedParticipants: [ChatRoomParticipant]
+  addedParticipants: [ChatRoomParticipant]
   clientMutationId: String
 }
 

--- a/packages/components/schema.graphql
+++ b/packages/components/schema.graphql
@@ -154,6 +154,19 @@ type ChatRoomCreatePayload {
   clientMutationId: String
 }
 
+input ChatRoomDeleteMessageInput {
+  id: ID!
+  clientMutationId: String
+}
+
+type ChatRoomDeleteMessagePayload {
+  """May contain more than one error for same field."""
+  errors: [ErrorType]
+  _debug: DjangoDebug
+  deletedMessage: MessageEdge
+  clientMutationId: String
+}
+
 """A Relay edge containing a `ChatRoom` and its cursor."""
 type ChatRoomEdge {
   """The item at the end of the edge"""
@@ -177,18 +190,17 @@ type ChatRoomEditMessagePayload {
   clientMutationId: String
 }
 
-type ChatRoomOnMessagesCountUpdate {
-  profile: Profile
+type ChatRoomOnMessage {
+  message: MessageEdge
 }
 
-type ChatRoomOnNewMessage {
-  message: MessageEdge
+type ChatRoomOnMessagesCountUpdate {
+  profile: Profile
 }
 
 type ChatRoomOnRoomUpdate {
   room: ChatRoomEdge
   removedParticipants: [ChatRoomParticipant]
-  addedParticipants: [ChatRoomParticipant]
 }
 
 type ChatRoomParticipant implements Node {
@@ -312,7 +324,6 @@ type ChatRoomUpdatePayload {
   _debug: DjangoDebug
   room: ChatRoomEdge
   removedParticipants: [ChatRoomParticipant]
-  addedParticipants: [ChatRoomParticipant]
   clientMutationId: String
 }
 
@@ -651,6 +662,7 @@ type Message implements Node {
   verb: Verbs
   room: ChatRoom
   inReplyTo: Message
+  deleted: Boolean!
   extraData: JSONString
   pk: Int!
   actionObject: Node
@@ -702,6 +714,7 @@ type Mutation {
   chatRoomUpdate(input: ChatRoomUpdateInput!): ChatRoomUpdatePayload
   chatRoomSendMessage(input: ChatRoomSendMessageInput!): ChatRoomSendMessagePayload
   chatRoomEditMessage(input: ChatRoomEditMessageInput!): ChatRoomEditMessagePayload
+  chatRoomDeleteMessage(input: ChatRoomDeleteMessageInput!): ChatRoomDeleteMessagePayload
   chatRoomReadMessages(input: ChatRoomReadMessagesInput!): ChatRoomReadMessagesPayload
   chatRoomUnread(input: ChatRoomUnreadInput!): ChatRoomUnreadPayload
   chatRoomArchive(input: ChatRoomArchiveInput!): ChatRoomArchivePayload
@@ -1650,7 +1663,7 @@ type RoleUpdatePayload {
 }
 
 type Subscription {
-  chatRoomOnNewMessage(roomId: ID!): ChatRoomOnNewMessage
+  chatRoomOnMessage(roomId: ID!): ChatRoomOnMessage
   chatRoomOnRoomUpdate(profileId: ID!): ChatRoomOnRoomUpdate
   chatRoomOnMessagesCountUpdate(profileId: ID!): ChatRoomOnMessagesCountUpdate
   onNotificationChange: OnNotificationChange


### PR DESCRIPTION
**Acceptance Criteria**

- Given I hover my mouse over a message, when the overlay 3 dots menu appears and I click on it, then I should see a "Delete" option in the menu. (Should already be implemented)
- Given I click the "Delete" option then, a dialog/delete message should confirm if I am sure that I want to delete the message.
  - The confirmation message changes if it's an individual chat or a group chat
- Given I click the "Delete" option to confirm, the text should be replaced with "You deleted this message" in gray font. 
  - For others in the chat (individual or in a group) the text should be replaced with "This message was deleted." in gray front. 
- A toast message should appear notifying that the message was deleted. 
  - Use the existing info icon, not the delete icon for now, nor the Undo button.  
  - Make the component as similar as the design as possible.
  - Use the new timed snack-bar component

**Guardrail**
The snackbar will not have the action button for now 

**Design Link**: https://www.figma.com/design/XRD6wSl1m8Kz6XUcAy5CLp/BaseApp---WEB?node-id=7763-127162&t=MOMbprMUFediIBZh-0 

**Note: The snackbar has been implemented in another PR**
https://github.com/silverlogic/baseapp-frontend/pull/207


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced chat room message deletion, allowing users to remove messages.
	- Messages now display a deleted status for improved clarity.
	- Enhanced the delete action with a simplified button label and added control to disable deletion when needed.
	- Improved error notifications during the deletion process.
	- Added support for distinguishing between group and individual messages in the message component.

- **Updates**
	- Updated version to 1.0.9, reflecting the addition of message deletion functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->