### PR TITLE
BA-2226 Three dot menu cleanup

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/components
 
+## 1.0.5
+
+### Patch Changes
+
+- Clean up the three dot menu in the chat header (do not display the option to leave a non-group chat, implement archiving chats from there)
+
 ## 1.0.4
 
 ### Patch Changes

--- a/packages/components/modules/messages/common/graphql/queries/ChatRoomQuery.ts
+++ b/packages/components/modules/messages/common/graphql/queries/ChatRoomQuery.ts
@@ -4,6 +4,7 @@ export const ChatRoomQuery = graphql`
   query ChatRoomQuery($roomId: ID!) {
     chatRoom(id: $roomId) {
       id
+      isArchived
       participantsCount
       ...TitleFragment
       ...MessagesListFragment

--- a/packages/components/modules/messages/web/ChatRoom/ChatRoomHeader/ChatRoomOptions/index.tsx
+++ b/packages/components/modules/messages/web/ChatRoom/ChatRoomHeader/ChatRoomOptions/index.tsx
@@ -5,23 +5,29 @@ import { MenuItem, MenuList, Typography } from '@mui/material'
 import { ChatRoomOptionsProps } from './types'
 
 const ChatRoomOptions: FC<ChatRoomOptionsProps> = ({
+  isArchived,
+  isArchiveMutationInFlight,
+  isGroup,
   onArchiveClicked,
   onDetailsClicked,
   onLeaveClicked,
 }) => (
   <MenuList>
-    {/* TODO: Implement archive room functionality */}
-    <MenuItem onClick={onArchiveClicked}>
-      <Typography variant="body2">Archive Chat</Typography>
+    <MenuItem onClick={onArchiveClicked} disabled={isArchiveMutationInFlight}>
+      <Typography variant="body2">{isArchived ? 'Unarchive Chat' : 'Archive Chat'}</Typography>
     </MenuItem>
-    <MenuItem onClick={onDetailsClicked}>
-      <Typography variant="body2">Group Details</Typography>
-    </MenuItem>
-    <MenuItem onClick={onLeaveClicked}>
-      <Typography variant="body2" color="error">
-        Leave Group
-      </Typography>
-    </MenuItem>
+    {isGroup ? (
+      <>
+        <MenuItem onClick={onDetailsClicked}>
+          <Typography variant="body2">Group Details</Typography>
+        </MenuItem>
+        <MenuItem onClick={onLeaveClicked}>
+          <Typography variant="body2" color="error">
+            Leave Group
+          </Typography>
+        </MenuItem>
+      </>
+    ) : null}
   </MenuList>
 )
 

--- a/packages/components/modules/messages/web/ChatRoom/ChatRoomHeader/ChatRoomOptions/types.ts
+++ b/packages/components/modules/messages/web/ChatRoom/ChatRoomHeader/ChatRoomOptions/types.ts
@@ -1,4 +1,7 @@
 export interface ChatRoomOptionsProps {
+  isArchived: boolean
+  isArchiveMutationInFlight: boolean
+  isGroup: boolean
   onArchiveClicked: () => void
   onDetailsClicked: () => void
   onLeaveClicked: () => void

--- a/packages/components/modules/messages/web/ChatRoom/ChatRoomHeader/types.ts
+++ b/packages/components/modules/messages/web/ChatRoom/ChatRoomHeader/types.ts
@@ -3,6 +3,7 @@ import { BoxProps } from '@mui/material'
 import { TitleFragment$key } from '../../../../../__generated__/TitleFragment.graphql'
 
 export interface ChatRoomHeaderProps {
+  isArchived: boolean
   participantsCount: number
   roomTitleRef: TitleFragment$key
   onDisplayGroupDetailsClicked: VoidFunction

--- a/packages/components/modules/messages/web/ChatRoom/index.tsx
+++ b/packages/components/modules/messages/web/ChatRoom/index.tsx
@@ -43,6 +43,7 @@ const ChatRoom: FC<ChatRoomProps> = ({
   return (
     <ChatRoomContainer>
       <ChatRoomHeader
+        isArchived={!!chatRoom.isArchived}
         participantsCount={chatRoom.participantsCount}
         roomTitleRef={chatRoom}
         onDisplayGroupDetailsClicked={onDisplayGroupDetailsClicked}

--- a/packages/components/modules/messages/web/ChatRoomsList/ChatRoomItem/index.tsx
+++ b/packages/components/modules/messages/web/ChatRoomsList/ChatRoomItem/index.tsx
@@ -9,9 +9,7 @@ import {
 } from '@baseapp-frontend/design-system/components/web/icons'
 
 import { Box, Badge as DefaultBadge, Typography } from '@mui/material'
-import { ConnectionHandler, useFragment } from 'react-relay'
-import { RecordSourceSelectorProxy } from 'relay-runtime'
-
+import { useFragment } from 'react-relay'
 import { LastMessageFragment$key } from '../../../../../__generated__/LastMessageFragment.graphql'
 import { TitleFragment$key } from '../../../../../__generated__/TitleFragment.graphql'
 import { UnreadMessagesCountFragment$key } from '../../../../../__generated__/UnreadMessagesCountFragment.graphql'
@@ -20,7 +18,6 @@ import {
   LastMessageFragment,
   TitleFragment,
   UnreadMessagesCountFragment,
-  getChatRoomConnections,
   useArchiveChatRoomMutation,
   useNameAndAvatar,
   useUnreadChatMutation,
@@ -93,13 +90,6 @@ const ChatRoomItem: FC<ChatRoomItemProps> = ({
                     profileId: currentProfile.id,
                     archive: !isInArchivedTab,
                   },
-                },
-                updater: (store: RecordSourceSelectorProxy<unknown>, data: any) => {
-                  if (!data?.errors) {
-                    getChatRoomConnections(store, currentProfile.id).forEach((connectionRecord) =>
-                      ConnectionHandler.deleteNode(connectionRecord, roomRef.id),
-                    )
-                  }
                 },
               })
             }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "sideEffects": false,
   "scripts": {
     "babel:bundle": "babel modules -d tmp-babel --extensions .ts,.tsx --ignore '**/__tests__/**','**/__storybook__/**'",


### PR DESCRIPTION
**Acceptance Criteria** 

- Given I am in an 1 on 1 Chat Room (which is a chat room that is not a group chat), when I open the 3 Dot menu, then I should not see the following options:

  - Leave Group

  - Group Details

- Given I am on any type of Chat room (1 on 1 or Group chat), when I click an option on the3 Dot menu then the menu should disappear.

- Implement the Archive behavior on the Archive Chat option in the 3 Dot Menu 

**Current behavior** 
Loom: [https://www.loom.com/share/64f71a85d88f46c69e3a79eed133efe0](https://www.loom.com/share/64f71a85d88f46c69e3a79eed133efe0) 

**Approvd** 
[https://app.approvd.io/silverlogic/BA/stories/38916](https://app.approvd.io/silverlogic/BA/stories/38916) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced chat room archiving functionality. Users can now archive or unarchive chat rooms directly from the chat room header with clear visual feedback.
  - The options menu has been updated to dynamically reflect the room's current state, including a disabled indicator during in-progress actions.
  - Enhanced group chat controls now provide refined options for managing group details, ensuring a more seamless and intuitive user experience.
  - Added a new field to display whether a chat room is archived, improving user awareness of chat room status.

- **Bug Fixes**
  - Improved error handling during chat room archiving to ensure a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->