### PR TITLE
Add members carousel

### DIFF
--- a/packages/components/modules/messages/EditGroup/AddMembersMobile/index.tsx
+++ b/packages/components/modules/messages/EditGroup/AddMembersMobile/index.tsx
@@ -187,6 +187,7 @@ const AddMembersMobile: FC<AddMembersMobileProps> = ({
               justifyContent: 'start',
               alignItems: 'center',
               padding: emptyParticipantsList ? 0 : '12px',
+              scrollbarWidth: 'none',
             },
           },
           ...(GroupChatMembersListProps?.MembersListProps ?? {}),


### PR DESCRIPTION
Acceptance Criteria 
Business Rules - Contacts to Add Carousel

Given I am on the Add Member List, when I select a new contact to be added to the group, then I should see a carousel of the selected contacts at the top of the modal. So that I have a quick summary of who I am intending to add.

The selected contacts should display their avatar and their first name.

Given I want to remove a contact selection, I should be able to remove it from this new section, so that I don't have to scroll until I find a contact to deselect it. 

But both methods of deselection should work:

Clicking the X on the bubble

Deselecting the checkbox in the list.

Given I add more contacts that the carousel can display appropriately, then I should be able to scroll the carousel horizontally in order to see the entire list of contacts I will add.

If a contact's name exceeds the maximum display length, it should be truncated and appended with three dots ("...") to indicate that the name continues.

We intend to reuse this "Add Member List component" in the old add member flow when creating a new group. 

Current behavior 

Expected behavior 

Code Snippet 

Design Link: https://www.figma.com/design/XRD6wSl1m8Kz6XUcAy5CLp/BaseApp---WEB?node-id=6999-403340&t=Hs9bSA9tuXgxsPGa-0 
