### PR TITLE
BA-2215: highlight existing member

### DIFF
--- a/packages/components/modules/messages/EditGroup/AddMemberCard/index.tsx
+++ b/packages/components/modules/messages/EditGroup/AddMemberCard/index.tsx
@@ -15,7 +15,8 @@ const AddMemberCard: FC<AddMemberCardProps> = ({
   profile: profileRef,
   handleAddMember,
   handleRemoveMember,
-  isMember = false,
+  isBeingAdded = false,
+  isExistingMember = false,
 }) => {
   const { id, image, name, urlPath } = useFragment(ProfileItemFragment, profileRef)
 
@@ -28,6 +29,16 @@ const AddMemberCard: FC<AddMemberCardProps> = ({
     }
   }
 
+  const getCaptionText = () => {
+    if (isExistingMember) {
+      return 'Already added to the group'
+    }
+    if (urlPath?.path) {
+      return `@${urlPath.path}`
+    }
+    return ''
+  }
+
   return (
     <MainContainer key={`chat-room-item-${id}`}>
       <AvatarWithPlaceholder
@@ -37,12 +48,21 @@ const AddMemberCard: FC<AddMemberCardProps> = ({
         sx={{ alignSelf: 'center', justifySelf: 'center' }}
       />
       <Box sx={{ display: 'grid', gridTemplateRows: 'repeat(2, minmax(0, 1fr))' }}>
-        <Typography variant="subtitle2">{name}</Typography>
-        <Typography variant="caption" color="text.secondary">
-          {urlPath?.path && `@${urlPath.path}`}
+        <Typography
+          variant="subtitle2"
+          color={!isExistingMember ? 'text.primary' : 'text.disabled'}
+        >
+          {name}
+        </Typography>
+        <Typography
+          variant="caption"
+          color={!isExistingMember ? 'text.secondary' : 'text.disabled'}
+          sx={{ fontStyle: !isExistingMember ? 'normal' : 'italic' }}
+        >
+          {getCaptionText()}
         </Typography>
       </Box>
-      <Checkbox checked={isMember} onChange={handleCheckboxChange} />
+      {!isExistingMember && <Checkbox checked={isBeingAdded} onChange={handleCheckboxChange} />}
     </MainContainer>
   )
 }

--- a/packages/components/modules/messages/EditGroup/AddMemberCard/types.ts
+++ b/packages/components/modules/messages/EditGroup/AddMemberCard/types.ts
@@ -5,5 +5,6 @@ export interface AddMemberCardProps {
   // TODO: type this better
   handleAddMember: (profile: any) => void
   handleRemoveMember: (profile: any) => void
-  isMember?: boolean
+  isBeingAdded: boolean
+  isExistingMember: boolean
 }

--- a/packages/components/modules/messages/EditGroup/AddMembersDialog/index.tsx
+++ b/packages/components/modules/messages/EditGroup/AddMembersDialog/index.tsx
@@ -34,6 +34,7 @@ const AddMembersDialog: FC<AddMembersDialogProps> = ({
   isPending,
   GroupChatMembersList = DefaultGroupChatMembersList,
   GroupChatMembersListProps = {},
+  existingMembers,
 }) => {
   const { sendToast } = useNotification()
 
@@ -168,7 +169,8 @@ const AddMembersDialog: FC<AddMembersDialogProps> = ({
                   profile={profile}
                   handleAddMember={handleAddMember}
                   handleRemoveMember={handleRemoveMember}
-                  isMember={participants.some((member) => member?.id === profile?.id)}
+                  isBeingAdded={participants.some((member) => member?.id === profile?.id)}
+                  isExistingMember={existingMembers.some((member) => member?.id === profile?.id)}
                 />
               )
             },

--- a/packages/components/modules/messages/EditGroup/AddMembersDialog/types.ts
+++ b/packages/components/modules/messages/EditGroup/AddMembersDialog/types.ts
@@ -2,6 +2,7 @@ import { FC } from 'react'
 
 import { ChatRoomsQuery$data } from '../../../../__generated__/ChatRoomsQuery.graphql'
 import { GroupChatMembersListProps } from '../../__shared__/GroupChatMembersList/types'
+import { ProfileNode } from '../../__shared__/types'
 
 export interface AddMembersDialogProps {
   allProfilesRef: ChatRoomsQuery$data
@@ -13,4 +14,5 @@ export interface AddMembersDialogProps {
   isPending: boolean
   GroupChatMembersList?: FC<GroupChatMembersListProps>
   GroupChatMembersListProps?: Partial<GroupChatMembersListProps>
+  existingMembers: ProfileNode[]
 }

--- a/packages/components/modules/messages/EditGroup/AddMembersMobile/index.tsx
+++ b/packages/components/modules/messages/EditGroup/AddMembersMobile/index.tsx
@@ -33,6 +33,7 @@ const AddMembersMobile: FC<AddMembersMobileProps> = ({
   isPending,
   GroupChatMembersList = DefaultGroupChatMembersList,
   GroupChatMembersListProps = {},
+  existingMembers = [],
 }) => {
   const { sendToast } = useNotification()
 
@@ -172,7 +173,8 @@ const AddMembersMobile: FC<AddMembersMobileProps> = ({
                 profile={profile}
                 handleAddMember={handleAddMember}
                 handleRemoveMember={handleRemoveMember}
-                isMember={participants.some((member) => member?.id === profile?.id)}
+                isBeingAdded={participants.some((member) => member?.id === profile?.id)}
+                isExistingMember={existingMembers.some((member) => member?.id === profile?.id)}
               />
             )
           },

--- a/packages/components/modules/messages/EditGroup/AddMembersMobile/types.ts
+++ b/packages/components/modules/messages/EditGroup/AddMembersMobile/types.ts
@@ -2,6 +2,7 @@ import { FC } from 'react'
 
 import { ChatRoomsQuery$data } from '../../../../__generated__/ChatRoomsQuery.graphql'
 import { GroupChatMembersListProps } from '../../__shared__/GroupChatMembersList/types'
+import { ProfileNode } from '../../__shared__/types'
 
 export interface AddMembersMobileProps {
   allProfilesRef: ChatRoomsQuery$data
@@ -12,4 +13,5 @@ export interface AddMembersMobileProps {
   isPending: boolean
   GroupChatMembersList?: FC<GroupChatMembersListProps>
   GroupChatMembersListProps?: Partial<GroupChatMembersListProps>
+  existingMembers: ProfileNode[]
 }

--- a/packages/components/modules/messages/EditGroup/index.tsx
+++ b/packages/components/modules/messages/EditGroup/index.tsx
@@ -155,6 +155,7 @@ const EditGroup: FC<EditGroupProps & { profileId: string }> = ({
         profileId={profileId}
         roomId={roomId}
         isPending={isPending}
+        existingMembers={participants}
       />
     )
 
@@ -168,6 +169,7 @@ const EditGroup: FC<EditGroupProps & { profileId: string }> = ({
         profileId={profileId}
         roomId={roomId}
         isPending={isPending}
+        existingMembers={participants}
       />
       <HeaderContainer>
         <IconButton onClick={onCancellation} aria-label="cancel editing group">


### PR DESCRIPTION
**Acceptance Criteria**
**Context**
We've already implemented the Add Member List, but if a Contact is already added to the group we have no mechanism to highlight it so that the Admin doesn't add it again. 

**Business Rules - Highlight Existing Contact on Add Member List**

- Given I am on the Add Member List, when I see a contact that is already a member of the group, then I should be able to identify that its already added and I should not be able to add it again.
  - The text format should be grayed out
  - Include "Already in this group" copy instead of their username.
  - The image is NOT grayed out
- The admin should not be able to select that contact to be added 

**Design Link:** https://www.figma.com/design/XRD6wSl1m8Kz6XUcAy5CLp/BaseApp---WEB?node-id=6999-397517&t=Hs9bSA9tuXgxsPGa-0 

**Approvd** 
https://app.approvd.io/projects/BA/stories/38004 
