### PR TITLE
BA-2245: decrease border radius on system messages

### DIFF
--- a/packages/components/modules/messages/web/MessagesList/MessagesGroup/SystemMessage/styled.tsx
+++ b/packages/components/modules/messages/web/MessagesList/MessagesGroup/SystemMessage/styled.tsx
@@ -3,7 +3,7 @@ import { Typography, styled } from '@mui/material'
 export const SystemMessageTypography = styled(Typography)(({ theme }) => ({
   alignSelf: 'center',
   backgroundColor: theme.palette.grey[300],
-  borderRadius: theme.spacing(1),
+  borderRadius: theme.spacing(0.5),
   marginBottom: theme.spacing(1),
   marginTop: theme.spacing(2),
   padding: theme.spacing(0.5, 1),


### PR DESCRIPTION
**Acceptance Criteria**

The system message component should follow the pixels that its defined on the figma designs right now the padding seems to be 12px instead of 8px. 

Check with TS for more questions. 

**Current behavior** 
Loom: https://www.loom.com/share/9e4a700105584111a13018f3c57b55f3 

**Approvd** 
https://app.approvd.io/silverlogic/BA/stories/38933

**Note**
After talking with Talita, it was decided to keep the 8px padding on system messages, but to reduce the radius to 4px. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Refined the system messages' visual design by reducing the border radius for a more sleek and compact appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->