### PR TITLE
BA-2392 RN Notifications: Divide List by Read

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/components
 
+## 1.0.30
+
+### Patch Changes
+
+- Native: Dividing notifications into unread/read
+
 ## 1.0.29
 
 ### Patch Changes

--- a/packages/components/modules/notifications/native/NotificationsList/Divider/index.tsx
+++ b/packages/components/modules/notifications/native/NotificationsList/Divider/index.tsx
@@ -1,0 +1,24 @@
+import { FC } from 'react'
+
+import { Text } from '@baseapp-frontend/design-system/components/native/typographies'
+import { View } from '@baseapp-frontend/design-system/components/native/views'
+import { useTheme } from '@baseapp-frontend/design-system/providers/native'
+
+import { createStyles } from './styles'
+
+const Divider: FC = () => {
+  const theme = useTheme()
+  const styles = createStyles(theme)
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.line} />
+      <View>
+        <Text variant="caption">Read</Text>
+      </View>
+      <View style={styles.line} />
+    </View>
+  )
+}
+
+export default Divider

--- a/packages/components/modules/notifications/native/NotificationsList/Divider/styles.ts
+++ b/packages/components/modules/notifications/native/NotificationsList/Divider/styles.ts
@@ -1,0 +1,25 @@
+import { Theme } from '@baseapp-frontend/design-system/styles/native'
+
+import { StyleSheet } from 'react-native'
+
+export const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    container: {
+      height: 30,
+      width: '100%',
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'center',
+      alignItems: 'center',
+      gap: 16,
+    },
+    line: {
+      height: 1,
+      width: 10,
+      backgroundColor: theme.colors.surface.disabled,
+      flexGrow: 1,
+    },
+    text: {
+      alignItems: 'center',
+    },
+  })

--- a/packages/components/modules/notifications/native/NotificationsList/NotificationItem/index.tsx
+++ b/packages/components/modules/notifications/native/NotificationsList/NotificationItem/index.tsx
@@ -10,6 +10,7 @@ import { NotificationItemProps } from './types'
 const NotificationItem: FC<NotificationItemProps> = ({
   notification: notificationRef,
   NotificationItemRenderer = DefaultNotificationItemRenderer,
+  refetch,
 }) => {
   const notification = useFragment(NotificationItemFragment, notificationRef)
 
@@ -18,6 +19,7 @@ const NotificationItem: FC<NotificationItemProps> = ({
   const markAsRead = () => {
     if (notification.unread) {
       commitMutation({
+        onCompleted: refetch,
         variables: {
           input: {
             read: true,

--- a/packages/components/modules/notifications/native/NotificationsList/NotificationItem/index.tsx
+++ b/packages/components/modules/notifications/native/NotificationsList/NotificationItem/index.tsx
@@ -19,6 +19,8 @@ const NotificationItem: FC<NotificationItemProps> = ({
   const markAsRead = () => {
     if (notification.unread) {
       commitMutation({
+        // TODO: check whether this is needed (clicking on a notification should navigate to the underlying comment,
+        // so the screen will not remain visible). If needed, check whether we can use optimistic updates
         onCompleted: refetch,
         variables: {
           input: {

--- a/packages/components/modules/notifications/native/NotificationsList/NotificationItem/types.ts
+++ b/packages/components/modules/notifications/native/NotificationsList/NotificationItem/types.ts
@@ -9,6 +9,7 @@ import { NotificationItemRendererProps } from './NotificationItemRenderer/types'
 export interface NotificationItemProps {
   notification: NotificationItemFragment$key
   NotificationItemRenderer?: FC<NotificationItemRendererProps>
+  refetch: VoidFunction
 }
 
 export interface GenericItemProps {

--- a/packages/components/modules/notifications/native/NotificationsList/index.tsx
+++ b/packages/components/modules/notifications/native/NotificationsList/index.tsx
@@ -16,6 +16,7 @@ import {
   useNotificationsSubscription,
 } from '../../common'
 import { NotificationsNode } from '../../common/types'
+import Divider from './Divider'
 import DefaultEmptyState from './EmptyState'
 import MarkAllAsReadButton from './MarkAllAsReadButton'
 import DefaultNotificationItem from './NotificationItem'
@@ -48,19 +49,24 @@ const NotificationsList: FC<NotificationsListProps> = ({
   )
 
   const refetchNotifications = () => {
-    refetch(options, { fetchPolicy: 'network-only' })
+    refetch(options, { fetchPolicy: 'store-and-network' })
   }
 
-  const renderNotificationItem = (notification: NotificationsNode) => {
+  const renderNotificationItem = (notification: NotificationsNode, index: number) => {
     if (!notification) return null
-
-    // TODO add notifications divider and unread/Read notifications as per design
+    let divider = null
+    if (!notification.unread && index > 0 && notifications[index - 1]?.unread) {
+      divider = <Divider />
+    }
     return (
-      <NotificationItem
-        key={`notification-${notification.id}`}
-        notification={notification}
-        {...NotificationItemProps}
-      />
+      <>
+        {divider}
+        <NotificationItem
+          notification={notification}
+          refetch={refetchNotifications}
+          {...NotificationItemProps}
+        />
+      </>
     )
   }
 
@@ -71,7 +77,7 @@ const NotificationsList: FC<NotificationsListProps> = ({
       <View style={styles.listContainer}>
         <InfiniteScrollerView
           data={notifications}
-          renderItem={({ item }: { item: NotificationsNode }) => renderNotificationItem(item)}
+          renderItem={({ item, index }: { item: NotificationsNode, index: number }) => renderNotificationItem(item, index)}
           estimatedItemSize={134}
           onEndReached={() => {
             if (hasNext) {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "sideEffects": false,
   "scripts": {
     "babel:transpile": "babel modules -d tmp-babel --extensions .ts,.tsx --ignore '**/__tests__/**','**/__storybook__/**'",


### PR DESCRIPTION
Description

As a user, on the BaseApp React Native,I would like to see dividers in my notification list based on how old the notifications are, In order to distinguish between recent and older notifications.

 
Acceptance Criteria 

- Given I have multiple notifications, when I open the notifications page, then the notifications should be grouped by Read/Unread and separated by a divider.

- The divider will have the "Read" Label

- The reverse chronological sort should be maintained inside each group. (Most recent first)

- Given a notification is mark as read, then it should go to the read group live.

  - This is for the case when we click on "Mark all as read button", where we don't redirect to another page.

- If everything is read, then the divider should be hidden. 

Approvd 
https://app.approvd.io/silverlogic/BA/stories/38686 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a visual divider in the notifications list to enhance readability.
  - Enabled an automatic refresh for notifications after marking them as read.
  - Optimized the notifications fetching strategy for a smoother and more responsive experience.
  - Added a new `Divider` component to improve layout structure within the notifications list.
- **Bug Fixes**
  - Improved organization of notifications by categorizing them into unread and read sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->