### PR TITLE
FEN-192 Do not hyperlink NavItems with children

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/components
 
+## 1.0.32
+
+### Patch Changes
+
+- Disables link for navigation elements with children and fixes vertical alignment
+
 ## 1.0.31
 
 ### Patch Changes

--- a/packages/components/modules/navigations/web/NavMini/NavSectionMini/NavList/NavItem/index.tsx
+++ b/packages/components/modules/navigations/web/NavMini/NavSectionMini/NavList/NavItem/index.tsx
@@ -32,6 +32,7 @@ const NavItem = forwardRef<HTMLDivElement, NavItemProps>(
         depth={depth}
         active={active}
         disabled={disabled}
+        disableRipple={hasChild}
         {...props}
       >
         <div className="relative">
@@ -80,6 +81,8 @@ const NavItem = forwardRef<HTMLDivElement, NavItemProps>(
           {content}
         </Link>
       )
+
+    if (hasChild) return content
 
     return (
       <Link

--- a/packages/components/modules/navigations/web/__shared__/NavSectionVertical/Group/NavList/NavItem/index.tsx
+++ b/packages/components/modules/navigations/web/__shared__/NavSectionVertical/Group/NavList/NavItem/index.tsx
@@ -39,13 +39,13 @@ const NavItem = forwardRef<HTMLDivElement, NavItemProps>(
         {...props}
       >
         {!subItem && icon && (
-          <Box component="span" className="icon">
+          <Box component="span" className="icon" sx={{ lineHeight: 1 }}>
             {icon}
           </Box>
         )}
 
         {subItem && icon ? (
-          <Box component="span" className="icon">
+          <Box component="span" className="icon" sx={{ lineHeight: 1 }}>
             {icon}
           </Box>
         ) : (

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "sideEffects": false,
   "scripts": {
     "babel:transpile": "babel modules -d tmp-babel --extensions .ts,.tsx --ignore '**/__tests__/**','**/__storybook__/**'",


### PR DESCRIPTION
Currently, clicking on an item with children in the sidebar navigation (NavVertical) only expands/collapses the children. However, when the sidebar is minimized (NavMini), the children appear on hovering, but clicking on the item navigates to the corresponding page (which might not exist). This PR unifies this behavior, by no longer hyperlinking items in NavMini if they have children.

I also added the lineHeight: 1 as explained here: [https://www.loom.com/share/5fa6bbbfde92484782a4986f7281a44f?sid=a3aae763-aa5a-428d-beb7-59ea63fe80ff](https://www.loom.com/share/5fa6bbbfde92484782a4986f7281a44f?sid=a3aae763-aa5a-428d-beb7-59ea63fe80ff) I'm not exactly sure what is happening there, looks like the 24x24 svg image is rendered one or two pixels lower than its bounding span of height 24 when the lineHeight of the span is 1.5 (maybe the lineHeight is not distributed equally above and below!?)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced navigation experience: Navigation items with sub-menus now avoid unnecessary visual distractions and offer a streamlined interaction for a smoother, more intuitive user journey.
  - Added a new prop to disable ripple effects for navigation items with child elements, improving user interaction.

- **Bug Fixes**
  - Fixed vertical alignment of navigation elements for a more consistent appearance in the user interface.

- **Style**
  - Consistent styling for icons in navigation items, ensuring uniform appearance regardless of item type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->