### PR TITLE
FEN-229: custom login method

### DIFF
--- a/packages/authentication/CHANGELOG.md
+++ b/packages/authentication/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/authentication
 
+## 4.2.3
+
+### Patch Changes
+
+- `useLogin` now supports custom `ApiClass` types, so when the login method changes, we can get the corresponding request/response types. The login form should also reflect the correct types if the schema is changed.
+
 ## 4.2.2
 
 ### Patch Changes

--- a/packages/authentication/index.ts
+++ b/packages/authentication/index.ts
@@ -15,4 +15,5 @@ export * from './services/user'
 
 export type * from './types/auth'
 export type * from './types/mfa'
+export type * from './types/profile'
 export type * from './types/user'

--- a/packages/authentication/modules/access/useLogin/index.ts
+++ b/packages/authentication/modules/access/useLogin/index.ts
@@ -31,17 +31,17 @@ import {
 import { CODE_VALIDATION_INITIAL_VALUES, CODE_VALIDATION_SCHEMA } from '../../mfa/constants'
 import { useCurrentProfile } from '../../profile'
 import { DEFAULT_INITIAL_VALUES, DEFAULT_VALIDATION_SCHEMA } from './constants'
-import type { UseLoginOptions } from './types'
+import type { ApiClass, LoginParams, UseLoginOptions } from './types'
 
-const useLogin = ({
+const useLogin = <TApiClass extends ApiClass = typeof AuthApi>({
   loginFormOptions = {},
   loginOptions = {},
   mfaOptions = {},
   accessKeyName = ACCESS_KEY_NAME,
   refreshKeyName = REFRESH_KEY_NAME,
-  ApiClass = AuthApi,
+  ApiClass = AuthApi as unknown as TApiClass,
   enableFormApiErrors = true,
-}: UseLoginOptions = {}) => {
+}: UseLoginOptions<TApiClass> = {}) => {
   const [mfaEphemeralToken, setMfaEphemeralToken] = useState<string | null>(null)
   const { setCurrentProfile } = useCurrentProfile()
 
@@ -83,7 +83,7 @@ const useLogin = ({
   }
 
   const form = useForm({
-    defaultValues: DEFAULT_INITIAL_VALUES,
+    defaultValues: DEFAULT_INITIAL_VALUES as LoginParams<TApiClass>,
     resolver: zodResolver(DEFAULT_VALIDATION_SCHEMA),
     mode: 'onBlur',
     ...loginFormOptions,

--- a/packages/authentication/modules/access/useLogin/types.ts
+++ b/packages/authentication/modules/access/useLogin/types.ts
@@ -2,19 +2,20 @@ import type { UseMutationOptions } from '@tanstack/react-query'
 import type { UseFormProps } from 'react-hook-form'
 
 import AuthApi from '../../../services/auth'
-import type {
-  CustomJWTKeyNames,
-  LoginMfaRequest,
-  LoginRequest,
-  LoginResponse,
-} from '../../../types/auth'
+import type { CustomJWTKeyNames, LoginMfaRequest, LoginResponse } from '../../../types/auth'
 
-type ApiClass = Pick<typeof AuthApi, 'login'>
+export type ApiClass = {
+  login: (...args: any[]) => Promise<any>
+}
 
-export interface UseLoginOptions extends CustomJWTKeyNames {
-  loginFormOptions?: UseFormProps<Partial<LoginRequest>>
-  loginOptions?: UseMutationOptions<LoginResponse, unknown, LoginRequest, any>
+export type LoginParams<T extends ApiClass> = Parameters<T['login']>[0]
+export type LoginReturn<T extends ApiClass> = Awaited<ReturnType<T['login']>>
+
+export interface UseLoginOptions<TApiClass extends ApiClass = typeof AuthApi>
+  extends CustomJWTKeyNames {
+  loginFormOptions?: UseFormProps<Partial<LoginParams<TApiClass>>>
+  loginOptions?: UseMutationOptions<LoginReturn<TApiClass>, unknown, LoginParams<TApiClass>, any>
   mfaOptions?: UseMutationOptions<LoginResponse, unknown, LoginMfaRequest, any>
-  ApiClass?: ApiClass
+  ApiClass?: TApiClass
   enableFormApiErrors?: boolean
 }

--- a/packages/authentication/modules/profile/index.ts
+++ b/packages/authentication/modules/profile/index.ts
@@ -1,3 +1,2 @@
 export { default as useCurrentProfile } from './useCurrentProfile'
 export * from './useCurrentProfile/constants'
-export type { MinimalProfile } from '../../types/profile'

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/authentication",
   "description": "Authentication modules.",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
- `authentication` package update - `v 4.2.3`
  - `useLogin` now supports custom `ApiClass` types, so when the login method changes, we can get the corresponding request/response types. The login form should also reflect the correct types if the schema is changed.
  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The login functionality now supports custom API types, allowing for greater flexibility and adaptability to changes in authentication methods.
  - The login form automatically updates to reflect the correct fields if the login schema changes.

- **Documentation**
  - Updated changelog to reflect the new version and enhancements.

- **Chores**
  - Package version updated to 4.2.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->