### PR TITLE
FEN-343 Add dropzone customization props

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/components
 
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/design-system@1.0.17
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "sideEffects": false,
   "scripts": {
     "babel:transpile": "babel modules -d tmp-babel --extensions .ts,.tsx --ignore '**/__tests__/**','**/__storybook__/**'",

--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/design-system
 
+## 1.0.17
+
+### Patch Changes
+
+- Add dropzone customization props
+
 ## 1.0.16
 
 ### Patch Changes

--- a/packages/design-system/components/web/dropzones/Dropzone/index.tsx
+++ b/packages/design-system/components/web/dropzones/Dropzone/index.tsx
@@ -11,7 +11,7 @@ import {
 import { Button, Card, Typography } from '@mui/material'
 import { useDropzone } from 'react-dropzone'
 
-import DropzonePreview from './DropzonePreview'
+import DefaultDropzonePreview from './DropzonePreview'
 import {
   AddFileButton,
   AddFileWrapper,
@@ -39,6 +39,12 @@ const Dropzone: FC<DropzoneProps> = ({
   multiple = false,
   asBase64 = true,
   onFileClick,
+  DropzonePreview = DefaultDropzonePreview,
+  DropzonePreviewProps = {},
+  DropZoneIcon = InsertPhotoOutlinedIcon,
+  DropZoneIconProps = {},
+  DropZoneCancelIcon = CancelIcon,
+  DropZoneCancelIconProps = {},
 }) => {
   const [files, setFiles] = useState<DropzoneProps['storedImg']>(storedImg)
   const { sendToast } = useNotification()
@@ -96,7 +102,7 @@ const Dropzone: FC<DropzoneProps> = ({
             <input {...getInputProps()} aria-label={ariaLabel} {...InputProps} />
             {isDragReject ? (
               <>
-                <CancelIcon />
+                <DropZoneCancelIcon {...DropZoneCancelIconProps} />
                 <Typography variant="body2" color="error.main">
                   File not accepted, please choose the correct type
                 </Typography>
@@ -106,13 +112,14 @@ const Dropzone: FC<DropzoneProps> = ({
               </>
             ) : (
               <>
-                <InsertPhotoOutlinedIcon
+                <DropZoneIcon
                   sx={{
                     width: '36px',
                     height: '36px',
                     marginBottom: '4px',
                     color: 'text.secondary',
                   }}
+                  {...DropZoneIconProps}
                 />
                 <Typography textAlign="center" variant="body2" color="text.primary">
                   {title || (
@@ -145,6 +152,7 @@ const Dropzone: FC<DropzoneProps> = ({
                 file={file}
                 key={`${(file as File)?.name}_${index}`}
                 handleRemoveFile={() => handleRemove(index)}
+                {...DropzonePreviewProps}
               />
             ))}
           </DropzoneContainer>
@@ -159,6 +167,7 @@ const Dropzone: FC<DropzoneProps> = ({
               isMini={false}
               file={files as string | File}
               handleRemoveFile={() => handleRemove()}
+              {...DropzonePreviewProps}
             />
           </Card>
         )}

--- a/packages/design-system/components/web/dropzones/Dropzone/types.ts
+++ b/packages/design-system/components/web/dropzones/Dropzone/types.ts
@@ -1,5 +1,6 @@
-import { CSSProperties, HTMLAttributes, InputHTMLAttributes } from 'react'
+import { CSSProperties, FC, HTMLAttributes, InputHTMLAttributes } from 'react'
 
+import { SvgIconProps } from '@mui/material'
 import { Theme } from '@mui/material/styles'
 import type { Accept, DropzoneOptions } from 'react-dropzone'
 
@@ -27,6 +28,12 @@ export interface BaseDropzoneProps {
   InputContainerStyle?: CSSProperties
   multiple?: boolean
   onFileClick?: (selectedFile: string | File | Blob, index?: number) => void
+  DropzonePreview?: FC<DropzonePreviewProps>
+  DropzonePreviewProps?: Partial<DropzonePreviewProps>
+  DropZoneIcon?: FC<SvgIconProps>
+  DropZoneIconProps?: Partial<SvgIconProps>
+  DropZoneCancelIcon?: FC<SvgIconProps>
+  DropZoneCancelIconProps?: Partial<SvgIconProps>
 }
 
 export interface DropzoneAsSingleBase64Props extends BaseDropzoneProps {

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/design-system",
   "description": "Design System components and configurations.",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "sideEffects": false,
   "scripts": {
     "tsup:bundle": "tsup --tsconfig tsconfig.build.json",


### PR DESCRIPTION
- `__package_name__` package update - `v __package_version__`
  - **changelog_info**
  - **changelog_info**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added options to customize the icons and preview component in the Dropzone, allowing users to provide their own icons and preview elements via new props.
	- Enabled passing additional properties to custom icons and preview components for enhanced flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->