### PR TITLE
BA-2564-current-profile-retrieve

### DIFF
--- a/packages/authentication/modules/access/useLogin/index.ts
+++ b/packages/authentication/modules/access/useLogin/index.ts
@@ -68,12 +68,14 @@ const useLogin = <TApiClass extends ApiClass = typeof AuthApi>({
           ? user.profile.image
           : `${baseUrl}${user.profile.image}`
       }
-      const userProfile = {
+
+      const currentProfile = {
         ...user.profile,
         image: absoluteImagePath,
       }
-      setCurrentProfile(userProfile)
-      await setTokenAsync(CURRENT_PROFILE_KEY_NAME, JSON.stringify(userProfile))
+
+      setCurrentProfile(currentProfile)
+      await setTokenAsync(CURRENT_PROFILE_KEY_NAME, JSON.stringify(currentProfile))
     }
 
     await setTokenAsync(accessKeyName, response.access, {

--- a/packages/authentication/modules/access/useLogin/index.ts
+++ b/packages/authentication/modules/access/useLogin/index.ts
@@ -68,7 +68,7 @@ const useLogin = <TApiClass extends ApiClass = typeof AuthApi>({
           ? user.profile.image
           : `${baseUrl}${user.profile.image}`
       }
-      setCurrentProfile({
+      await setCurrentProfile({
         ...user.profile,
         image: absoluteImagePath,
       })

--- a/packages/authentication/modules/access/useLogin/index.ts
+++ b/packages/authentication/modules/access/useLogin/index.ts
@@ -28,7 +28,8 @@ import {
   isLoginMfaResponse,
 } from '../../../utils/login'
 import { CODE_VALIDATION_INITIAL_VALUES, CODE_VALIDATION_SCHEMA } from '../../mfa/constants'
-import { CURRENT_PROFILE_KEY_NAME, useCurrentProfile } from '../../profile'
+import { useCurrentProfile } from '../../profile'
+import { setProfileExpoStorage } from '../../profile/utils'
 import { DEFAULT_INITIAL_VALUES, DEFAULT_VALIDATION_SCHEMA } from './constants'
 import type { ApiClass, LoginParams, UseLoginOptions } from './types'
 
@@ -75,7 +76,7 @@ const useLogin = <TApiClass extends ApiClass = typeof AuthApi>({
       }
 
       setCurrentProfile(currentProfile)
-      await setTokenAsync(CURRENT_PROFILE_KEY_NAME, JSON.stringify(currentProfile))
+      await setProfileExpoStorage(currentProfile)
     }
 
     await setTokenAsync(accessKeyName, response.access, {

--- a/packages/authentication/modules/access/useLogin/index.ts
+++ b/packages/authentication/modules/access/useLogin/index.ts
@@ -28,7 +28,7 @@ import {
   isLoginMfaResponse,
 } from '../../../utils/login'
 import { CODE_VALIDATION_INITIAL_VALUES, CODE_VALIDATION_SCHEMA } from '../../mfa/constants'
-import { useCurrentProfile } from '../../profile'
+import { CURRENT_PROFILE_KEY_NAME, useCurrentProfile } from '../../profile'
 import { DEFAULT_INITIAL_VALUES, DEFAULT_VALIDATION_SCHEMA } from './constants'
 import type { ApiClass, LoginParams, UseLoginOptions } from './types'
 
@@ -68,10 +68,12 @@ const useLogin = <TApiClass extends ApiClass = typeof AuthApi>({
           ? user.profile.image
           : `${baseUrl}${user.profile.image}`
       }
-      await setCurrentProfile({
+      const userProfile = {
         ...user.profile,
         image: absoluteImagePath,
-      })
+      }
+      setCurrentProfile(userProfile)
+      await setTokenAsync(CURRENT_PROFILE_KEY_NAME, JSON.stringify(userProfile))
     }
 
     await setTokenAsync(accessKeyName, response.access, {

--- a/packages/authentication/modules/access/useLogin/index.ts
+++ b/packages/authentication/modules/access/useLogin/index.ts
@@ -54,23 +54,24 @@ const useLogin = <TApiClass extends ApiClass = typeof AuthApi>({
       return
     }
 
-    // TODO: adapt this flow to work with mobile
-    if (!isMobilePlatform()) {
-      const user = decodeJWT<User>(response.access)
-      if (user) {
-        // TODO: handle the absolute image path on the backend
-        const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL?.replace('/v1', '')
-        let absoluteImagePath = null
-        if (user?.profile?.image) {
-          absoluteImagePath = user.profile.image.startsWith('http')
-            ? user.profile.image
-            : `${baseUrl}${user.profile.image}`
-        }
-        setCurrentProfile({
-          ...user.profile,
-          image: absoluteImagePath,
-        })
+    const isWebPlatform = !isMobilePlatform()
+
+    const user = decodeJWT<User>(response.access)
+    if (user) {
+      const API_BASE_URL = isWebPlatform
+        ? process.env.NEXT_PUBLIC_API_BASE_URL
+        : process.env.EXPO_PUBLIC_API_BASE_URL
+      const baseUrl = API_BASE_URL?.replace('/v1', '')
+      let absoluteImagePath = null
+      if (user?.profile?.image) {
+        absoluteImagePath = user.profile.image.startsWith('http')
+          ? user.profile.image
+          : `${baseUrl}${user.profile.image}`
       }
+      setCurrentProfile({
+        ...user.profile,
+        image: absoluteImagePath,
+      })
     }
 
     await setTokenAsync(accessKeyName, response.access, {

--- a/packages/authentication/modules/access/useLogout/index.ts
+++ b/packages/authentication/modules/access/useLogout/index.ts
@@ -10,6 +10,7 @@ import { useQueryClient } from '@tanstack/react-query'
 
 import { MFA_API_KEY } from '../../../services/mfa'
 import { USER_API_KEY } from '../../../services/user'
+import { CURRENT_PROFILE_KEY_NAME } from '../../profile/useCurrentProfile/constants'
 import type { UseLogoutOptions } from './types'
 
 const useLogout = ({
@@ -23,6 +24,7 @@ const useLogout = ({
   const logout = async () => {
     await removeTokenAsync(accessKeyName)
     await removeTokenAsync(refreshKeyName)
+    await removeTokenAsync(CURRENT_PROFILE_KEY_NAME)
     queryClient.resetQueries({ queryKey: USER_API_KEY.getUser() })
     queryClient.resetQueries({ queryKey: MFA_API_KEY.default })
     onLogout?.()

--- a/packages/authentication/modules/profile/useCurrentProfile/store.ts
+++ b/packages/authentication/modules/profile/useCurrentProfile/store.ts
@@ -1,5 +1,3 @@
-import { setTokenAsync } from '@baseapp-frontend/utils'
-
 import Cookies from 'js-cookie'
 import { type StoreApi, createStore } from 'zustand'
 
@@ -14,13 +12,11 @@ const createProfileStore = (
 ): StoreApi<CurrentProfileState> =>
   createStore<CurrentProfileState>()((set) => ({
     currentProfile: initialProfile,
-    setCurrentProfile: async (profile: MinimalProfile | null) => {
+    setCurrentProfile: (profile: MinimalProfile | null) => {
       Cookies.set(CURRENT_PROFILE_KEY_NAME, JSON.stringify(profile))
       set(() => ({ currentProfile: profile }))
-      await setTokenAsync(CURRENT_PROFILE_KEY_NAME, JSON.stringify(profile))
     },
-    updateProfileIfActive: async (profile: MinimalProfile) => {
-      await setTokenAsync(CURRENT_PROFILE_KEY_NAME, JSON.stringify(profile))
+    updateProfileIfActive: (profile: MinimalProfile) => {
       set((state) => {
         if (state.currentProfile?.id === profile.id) {
           Cookies.set(CURRENT_PROFILE_KEY_NAME, JSON.stringify(profile))

--- a/packages/authentication/modules/profile/useCurrentProfile/store.ts
+++ b/packages/authentication/modules/profile/useCurrentProfile/store.ts
@@ -1,3 +1,5 @@
+import { setTokenAsync } from '@baseapp-frontend/utils'
+
 import Cookies from 'js-cookie'
 import { type StoreApi, createStore } from 'zustand'
 
@@ -12,11 +14,13 @@ const createProfileStore = (
 ): StoreApi<CurrentProfileState> =>
   createStore<CurrentProfileState>()((set) => ({
     currentProfile: initialProfile,
-    setCurrentProfile: (profile: MinimalProfile | null) => {
+    setCurrentProfile: async (profile: MinimalProfile | null) => {
       Cookies.set(CURRENT_PROFILE_KEY_NAME, JSON.stringify(profile))
       set(() => ({ currentProfile: profile }))
+      await setTokenAsync(CURRENT_PROFILE_KEY_NAME, JSON.stringify(profile))
     },
-    updateProfileIfActive: (profile: MinimalProfile) => {
+    updateProfileIfActive: async (profile: MinimalProfile) => {
+      await setTokenAsync(CURRENT_PROFILE_KEY_NAME, JSON.stringify(profile))
       set((state) => {
         if (state.currentProfile?.id === profile.id) {
           Cookies.set(CURRENT_PROFILE_KEY_NAME, JSON.stringify(profile))

--- a/packages/authentication/modules/profile/utils.ts
+++ b/packages/authentication/modules/profile/utils.ts
@@ -1,0 +1,8 @@
+import { setTokenAsync } from '@baseapp-frontend/utils'
+
+import { MinimalProfile } from '../../types/profile'
+import { CURRENT_PROFILE_KEY_NAME } from './useCurrentProfile/constants'
+
+export const setProfileExpoStorage = async (profile: MinimalProfile) => {
+  await setTokenAsync(CURRENT_PROFILE_KEY_NAME, JSON.stringify(profile))
+}

--- a/packages/components/modules/profiles/web/ProfileSettingsComponent/index.tsx
+++ b/packages/components/modules/profiles/web/ProfileSettingsComponent/index.tsx
@@ -111,13 +111,14 @@ const ProfileSettingsComponent: FC<ProfileSettingsComponentProps> = ({ profile: 
 
   useEffect(() => {
     if (profile) {
-      updateProfileIfActive({
+      const newProfile = {
         id: profile.id,
         name: profile.name ?? null,
         urlPath: profile.urlPath?.path ?? null,
         image: profile.image?.url ?? null,
-      })
-      setTokenAsync(CURRENT_PROFILE_KEY_NAME, JSON.stringify(profile))
+      }
+      updateProfileIfActive(newProfile)
+      setTokenAsync(CURRENT_PROFILE_KEY_NAME, JSON.stringify(newProfile))
     }
   }, [profile?.id, profile?.name, profile?.urlPath?.path, profile?.image?.url])
 

--- a/packages/components/modules/profiles/web/ProfileSettingsComponent/index.tsx
+++ b/packages/components/modules/profiles/web/ProfileSettingsComponent/index.tsx
@@ -2,7 +2,8 @@
 
 import { FC, useEffect } from 'react'
 
-import { CURRENT_PROFILE_KEY_NAME, useCurrentProfile } from '@baseapp-frontend/authentication'
+import { useCurrentProfile } from '@baseapp-frontend/authentication'
+import { setProfileExpoStorage } from '@baseapp-frontend/authentication/modules/profile/utils'
 import { CircledAvatar } from '@baseapp-frontend/design-system/components/web/avatars'
 import { FileUploadButton } from '@baseapp-frontend/design-system/components/web/buttons'
 import { UsernameIcon } from '@baseapp-frontend/design-system/components/web/icons'
@@ -12,12 +13,7 @@ import {
   TextField,
   TextareaField,
 } from '@baseapp-frontend/design-system/components/web/inputs'
-import {
-  filterDirtyValues,
-  setFormRelayErrors,
-  setTokenAsync,
-  useNotification,
-} from '@baseapp-frontend/utils'
+import { filterDirtyValues, setFormRelayErrors, useNotification } from '@baseapp-frontend/utils'
 
 import { zodResolver } from '@hookform/resolvers/zod'
 import LoadingButton from '@mui/lab/LoadingButton'
@@ -118,7 +114,7 @@ const ProfileSettingsComponent: FC<ProfileSettingsComponentProps> = ({ profile: 
         image: profile.image?.url ?? null,
       }
       updateProfileIfActive(newProfile)
-      setTokenAsync(CURRENT_PROFILE_KEY_NAME, JSON.stringify(newProfile))
+      setProfileExpoStorage(newProfile)
     }
   }, [profile?.id, profile?.name, profile?.urlPath?.path, profile?.image?.url])
 

--- a/packages/components/modules/profiles/web/ProfileSettingsComponent/index.tsx
+++ b/packages/components/modules/profiles/web/ProfileSettingsComponent/index.tsx
@@ -2,7 +2,7 @@
 
 import { FC, useEffect } from 'react'
 
-import { useCurrentProfile } from '@baseapp-frontend/authentication'
+import { CURRENT_PROFILE_KEY_NAME, useCurrentProfile } from '@baseapp-frontend/authentication'
 import { CircledAvatar } from '@baseapp-frontend/design-system/components/web/avatars'
 import { FileUploadButton } from '@baseapp-frontend/design-system/components/web/buttons'
 import { UsernameIcon } from '@baseapp-frontend/design-system/components/web/icons'
@@ -12,7 +12,12 @@ import {
   TextField,
   TextareaField,
 } from '@baseapp-frontend/design-system/components/web/inputs'
-import { filterDirtyValues, setFormRelayErrors, useNotification } from '@baseapp-frontend/utils'
+import {
+  filterDirtyValues,
+  setFormRelayErrors,
+  setTokenAsync,
+  useNotification,
+} from '@baseapp-frontend/utils'
 
 import { zodResolver } from '@hookform/resolvers/zod'
 import LoadingButton from '@mui/lab/LoadingButton'
@@ -112,6 +117,7 @@ const ProfileSettingsComponent: FC<ProfileSettingsComponentProps> = ({ profile: 
         urlPath: profile.urlPath?.path ?? null,
         image: profile.image?.url ?? null,
       })
+      setTokenAsync(CURRENT_PROFILE_KEY_NAME, JSON.stringify(profile))
     }
   }, [profile?.id, profile?.name, profile?.urlPath?.path, profile?.image?.url])
 


### PR DESCRIPTION
This PR fix setCurrentProfile, UpdateCurrentProfile and getCurrentProfile for mobile.

Since Cookies do not work on React Native this is now being handled through Expo Store.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User profile data, including profile image URLs, is now consistently stored and updated for both web and mobile platforms.
  * Profile information is automatically saved whenever updates occur in profile settings.

* **Bug Fixes**
  * Ensured proper cleanup of stored profile data during logout, improving user privacy and session management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->