### PR TITLE
Hotfix/fix profile settings component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/components
 
+## 1.2.4
+
+### Minor Changes
+
+- Remove setProfileExpoStorage from web component ProfileSettingsComponent
+
 ## 1.2.3
 
 ### Patch Changes

--- a/packages/components/modules/profiles/web/ProfileSettingsComponent/index.tsx
+++ b/packages/components/modules/profiles/web/ProfileSettingsComponent/index.tsx
@@ -3,7 +3,6 @@
 import { FC, useEffect } from 'react'
 
 import { useCurrentProfile } from '@baseapp-frontend/authentication'
-import { setProfileExpoStorage } from '@baseapp-frontend/authentication/modules/profile/utils'
 import { CircledAvatar } from '@baseapp-frontend/design-system/components/web/avatars'
 import { FileUploadButton } from '@baseapp-frontend/design-system/components/web/buttons'
 import { UsernameIcon } from '@baseapp-frontend/design-system/components/web/icons'
@@ -114,7 +113,6 @@ const ProfileSettingsComponent: FC<ProfileSettingsComponentProps> = ({ profile: 
         image: profile.image?.url ?? null,
       }
       updateProfileIfActive(newProfile)
-      setProfileExpoStorage(newProfile)
     }
   }, [profile?.id, profile?.name, profile?.urlPath?.path, profile?.image?.url])
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "sideEffects": false,
   "scripts": {
     "babel:transpile": "babel modules -d tmp-babel --extensions .ts,.tsx --ignore '**/__tests__/**','**/__storybook__/**'",


### PR DESCRIPTION
- Removes `setProfileExpoStorage` from `ProfileSettingsComponent`. This is not something we want since this function is used to manage the ExpoStorage. Which is something inexistent in the web version.
- Upgrade `baseapp-frontend/components` version to `1.2.4`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the components package to version 1.2.4.
  * Updated the changelog to reflect recent changes.

* **Bug Fixes**
  * Removed an unused function from the Profile Settings component to streamline profile updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->