### PR TITLE
graphql/environment: send Current-Profile on subscription/websocket connections

### DIFF
--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/graphql
 
+## 1.3.2
+
+### Patch Changes
+
+- Send Current-Profile param on subscription/websocket connection
+
 ## 1.3.1
 
 ### Patch Changes

--- a/packages/graphql/config/environment.ts
+++ b/packages/graphql/config/environment.ts
@@ -1,4 +1,5 @@
-import { ACCESS_KEY_NAME, getExpoConstant } from '@baseapp-frontend/utils'
+import { CURRENT_PROFILE_KEY_NAME, MinimalProfile } from '@baseapp-frontend/authentication'
+import { ACCESS_KEY_NAME, getExpoConstant, parseString } from '@baseapp-frontend/utils'
 import { baseAppFetch } from '@baseapp-frontend/utils/functions/fetch/baseAppFetch'
 import { getToken } from '@baseapp-frontend/utils/functions/token/getToken'
 
@@ -100,8 +101,13 @@ const wsClient = createClient({
   url: (process.env.NEXT_PUBLIC_WS_RELAY_ENDPOINT ?? EXPO_PUBLIC_WS_RELAY_ENDPOINT) as string,
   connectionParams: () => {
     const Authorization = getToken(ACCESS_KEY_NAME)
+    const CurrentProfileStr = getToken(CURRENT_PROFILE_KEY_NAME) || undefined
+    const CurrentProfile = parseString<MinimalProfile>(CurrentProfileStr)
     if (!Authorization) return {}
-    return { Authorization }
+    return {
+      Authorization,
+      'Current-Profile': CurrentProfile ? CurrentProfile.id : undefined,
+    }
   },
   retryAttempts: Infinity,
   webSocketImpl: WebSocket,

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/graphql",
   "description": "GraphQL configurations and utilities",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -13,6 +13,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "dependencies": {
+    "@baseapp-frontend/authentication": "workspace:*",
     "graphql": "catalog:graphql",
     "graphql-ws": "catalog:graphql",
     "isomorphic-ws": "catalog:graphql",
@@ -28,7 +29,6 @@
     "react": "catalog:react19"
   },
   "devDependencies": {
-    "@baseapp-frontend/authentication": "workspace:*",
     "@baseapp-frontend/config": "workspace:*",
     "@baseapp-frontend/tsconfig": "workspace:*",
     "@types/js-cookie": "catalog:",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -28,6 +28,7 @@
     "react": "catalog:react19"
   },
   "devDependencies": {
+    "@baseapp-frontend/authentication": "workspace:*",
     "@baseapp-frontend/config": "workspace:*",
     "@baseapp-frontend/tsconfig": "workspace:*",
     "@types/js-cookie": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1235,6 +1235,9 @@ importers:
         specifier: catalog:graphql
         version: 19.0.0
     devDependencies:
+      '@baseapp-frontend/authentication':
+        specifier: workspace:*
+        version: link:../authentication
       '@baseapp-frontend/config':
         specifier: workspace:*
         version: link:../config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1201,6 +1201,9 @@ importers:
 
   packages/graphql:
     dependencies:
+      '@baseapp-frontend/authentication':
+        specifier: workspace:*
+        version: link:../authentication
       '@baseapp-frontend/utils':
         specifier: workspace:*
         version: link:../utils
@@ -1235,9 +1238,6 @@ importers:
         specifier: catalog:graphql
         version: 19.0.0
     devDependencies:
-      '@baseapp-frontend/authentication':
-        specifier: workspace:*
-        version: link:../authentication
       '@baseapp-frontend/config':
         specifier: workspace:*
         version: link:../config


### PR DESCRIPTION
Make it send Current-Profile param on subscription/websocket connection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for sending the "Current-Profile" parameter on subscription and websocket connections.

* **Chores**
  * Updated package version to 1.3.2 in the changelog and package metadata.
  * Added a new dependency on the authentication module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->