### PR TITLE
Feature/react native subscriptions improvement

### DIFF
--- a/packages/authentication/CHANGELOG.md
+++ b/packages/authentication/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/authentication
 
+## 5.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/utils@4.0.1
+
 ## 5.0.1
 
 ### Patch Changes

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/authentication",
   "description": "Authentication modules.",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @baseapp-frontend/components
 
+## 1.2.8
+
+### Minor Changes
+
+- Improved the `useMessagesListSubscription` hook to subscribe and unsubscribe based on the application's state — e.g., when the app goes inactive and then returns to the foreground, or vice versa.
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/utils@4.0.1
+  - @baseapp-frontend/authentication@5.0.2
+  - @baseapp-frontend/design-system@1.0.21
+  - @baseapp-frontend/graphql@1.3.3
+
 ## 1.2.7
 
 ### Minor Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "sideEffects": false,
   "scripts": {
     "babel:transpile": "babel modules -d tmp-babel --extensions .ts,.tsx --ignore '**/__tests__/**','**/__storybook__/**'",

--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/design-system
 
+## 1.0.21
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/utils@4.0.1
+
 ## 1.0.20
 
 ### Patch Changes

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/design-system",
   "description": "Design System components and configurations.",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "sideEffects": false,
   "scripts": {
     "tsup:bundle": "tsup --tsconfig tsconfig.build.json",

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @baseapp-frontend/graphql
 
+## 1.3.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/utils@4.0.1
+  - @baseapp-frontend/authentication@5.0.2
+
 ## 1.3.2
 
 ### Patch Changes

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/graphql",
   "description": "GraphQL configurations and utilities",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/provider/CHANGELOG.md
+++ b/packages/provider/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/provider
 
+## 2.0.15
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/utils@4.0.1
+
 ## 2.0.14
 
 ### Patch Changes

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/provider",
   "description": "Providers for React Query and Emotion.",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,33 +1,34 @@
 # @baseapp-frontend/utils
 
+## 4.0.1
+
+### Minor Changes
+
+- Introduced a new `useAppStateSubscription` hook that allows developers to register a callback (onAppResume) which runs whenever the app returns to the foreground. E.g. after a user unlocks their device or switches back to the app.
+
 ## 4.0.0
 
 ### Major Changes
 
 - **BREAKING:** Removed SSR support from cookie and token functions
-
   - Added `'use client'` directive to `getCookie`, `getToken`, `setTokenAsync`, and `removeTokenAsync` - these are now client-side only
   - Removed `noSSR` parameter from `getCookie`, `getToken`, and related types
   - Removed `getCookieAsync` function entirely
   - For server-side token retrieval, use the new `getTokenSSR` function instead
 
 - **BREAKING:** Removed deprecated `getTokenAsync` function
-
   - Deleted `getTokenAsync` function and all related tests
 
 - **BREAKING:** Removed deprecated cookie constants
-
   - Deleted `ACCESS_COOKIE_NAME` and `REFRESH_COOKIE_NAME` constants
   - These were already deprecated in favor of `ACCESS_KEY_NAME` and `REFRESH_KEY_NAME`
 
 - **BREAKING:** Updated `refreshAccessToken` API
-
   - Now requires explicit `refreshToken` parameter object
   - Updated function signature: `refreshAccessToken({ refreshToken, accessKeyName, refreshKeyName })`
   - No longer retrieves refresh token internally
 
 - **BREAKING:** Removed `ServerSideRenderingOption` type
-
   - Deleted `types/server.ts` file entirely
   - Updated all function signatures to remove SSR-related options
 

--- a/packages/utils/hooks/useAppStateSubscription/index.ts
+++ b/packages/utils/hooks/useAppStateSubscription/index.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react'
+
+import { AppState, AppStateStatus } from 'react-native'
+
+// Executes a callable when the app resumes.
+// E.g. user blocks the app and unblock it later.
+export const useAppStateSubscription = (onAppResume: () => void) => {
+  const appState = useRef<AppStateStatus>(AppState.currentState)
+
+  useEffect(() => {
+    const handleAppStateChange = (nextAppState: AppStateStatus) => {
+      if (appState.current.match(/inactive|background/) && nextAppState === 'active') {
+        onAppResume()
+      }
+      appState.current = nextAppState
+    }
+
+    const stateChangeSubscription = AppState.addEventListener('change', handleAppStateChange)
+    return () => {
+      stateChangeSubscription.remove()
+    }
+  }, [onAppResume])
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/utils",
   "description": "Util functions, constants and types.",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/wagtail/CHANGELOG.md
+++ b/packages/wagtail/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @baseapp-frontend/wagtail
 
+## 1.0.35
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/utils@4.0.1
+  - @baseapp-frontend/design-system@1.0.21
+  - @baseapp-frontend/graphql@1.3.3
+
 ## 1.0.34
 
 ### Patch Changes

--- a/packages/wagtail/package.json
+++ b/packages/wagtail/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/wagtail",
   "description": "BaseApp Wagtail",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
This PR introduces two key changes to improve the reliability of GraphQL subscriptions when the app transitions between background and foreground states:

1. New Hook: `useAppStateSubscription`
Added a reusable hook that listens to app state changes using React Native’s AppState API. Executes a provided callback (onAppResume) when the app returns to the foreground (e.g., after being backgrounded or locked).

Useful for re-subscribing to real-time data or refetching stale content.

Example:

```js
AppStateSubscription(() => {
  refetch({ id: chatRoom.id }, { fetchPolicy: 'store-and-network' })
})
```

2. Improved `useMessagesListSubscription` Hook
Enhanced the subscription lifecycle by subscribing and unsubscribing based on the app's active/inactive state.
Ensures real-time updates are re-established automatically after app resumes from the background or device unlock.
Prevents missed events or stale subscriptions due to suspended WebSocket connections on iOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new hook to detect when the app returns to the foreground.

* **Improvements**
  * Enhanced message subscription logic to better handle app state transitions, providing more reliable updates when the app becomes active or inactive.

* **Chores**
  * Updated several internal dependencies across packages to their latest versions.
  * Incremented package versions and updated changelogs for improved tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->