### PR TITLE
Account Deletion - Remove Deleted Account Info from Comments

### DIFF
--- a/packages/components/modules/activity-log/web/ActivityLogComponent/LogGroups/index.tsx
+++ b/packages/components/modules/activity-log/web/ActivityLogComponent/LogGroups/index.tsx
@@ -35,6 +35,10 @@ const LogGroups: FC<LogGroupsProps> = ({
       />
     )
   }
+  const renderUserName = (group: LogGroup) => {
+    if (group.logs[0]?.user == null) return 'Deleted User'
+    return group.logs[0]?.user?.fullName
+  }
 
   const renderItemContent = (group: LogGroup) => (
     <Box
@@ -54,7 +58,7 @@ const LogGroups: FC<LogGroupsProps> = ({
           alt={group.logs[0]?.user?.fullName ?? 'User activity log avatar'}
         />
         <Typography variant="subtitle2" mb="6px">
-          {group.logs[0]?.user?.fullName}
+          {renderUserName(group)}
         </Typography>
       </Box>
       {group.logs.map((log: ActivityLogNode, index: number) =>

--- a/packages/components/modules/comments/web/CommentItem/index.tsx
+++ b/packages/components/modules/comments/web/CommentItem/index.tsx
@@ -64,7 +64,7 @@ const CommentItem: FC<CommentItemProps> = ({
   const [deleteComment, isDeletingComment] = useCommentDeleteMutation()
 
   const profileUrl = `${profilePath}/${comment?.user?.pk}`
-  const hasUser = Boolean(comment.user)
+  const hasUser = Boolean(comment?.user)
 
   const showReplies = () => {
     if (isReplyExpanded) return

--- a/packages/components/modules/comments/web/CommentItem/index.tsx
+++ b/packages/components/modules/comments/web/CommentItem/index.tsx
@@ -64,6 +64,7 @@ const CommentItem: FC<CommentItemProps> = ({
   const [deleteComment, isDeletingComment] = useCommentDeleteMutation()
 
   const profileUrl = `${profilePath}/${comment?.user?.pk}`
+  const hasUser = Boolean(comment.user)
 
   const showReplies = () => {
     if (isReplyExpanded) return
@@ -95,7 +96,15 @@ const CommentItem: FC<CommentItemProps> = ({
     })
     showReplies()
   }
+  const renderUserName = () => {
+    if (!hasUser) return <Typography variant="subtitle2">Deleted User</Typography>
 
+    return (
+      <Link href={profileUrl}>
+        <Typography variant="subtitle2">{comment.user?.fullName}</Typography>
+      </Link>
+    )
+  }
   const renderCommentContent = () => {
     if (isEditMode)
       return (
@@ -143,18 +152,18 @@ const CommentItem: FC<CommentItemProps> = ({
         >
           <CommentContainer>
             <ClickableAvatar
+              deletedUser={!hasUser}
               width={40}
               height={40}
               alt={comment.user?.fullName ?? `Comment's user avatar`}
               src={comment.user?.avatar?.url}
               onClick={() => router.push(profileUrl)}
             />
+
             <div className="grid gap-3">
               <div className="grid grid-cols-1 justify-start">
                 <div className="grid grid-cols-[repeat(2,max-content)] items-center gap-2">
-                  <Link href={profileUrl}>
-                    <Typography variant="subtitle2">{comment.user?.fullName}</Typography>
-                  </Link>
+                  {renderUserName()}
                   <CommentPinnedBadge isPinned={comment.isPinned} />
                 </div>
                 {renderCommentContent()}
@@ -162,12 +171,14 @@ const CommentItem: FC<CommentItemProps> = ({
               <div className="flex justify-between">
                 <div className="grid grid-cols-[repeat(2,max-content)] gap-4">
                   <CommentReactionButton target={comment} />
-                  <CommentReplyButton
-                    onReply={replyToComment}
-                    isLoadingReplies={isLoadingReplies}
-                    commentId={comment.id}
-                    totalCommentsCount={comment.commentsCount.total}
-                  />
+                  {hasUser && (
+                    <CommentReplyButton
+                      onReply={replyToComment}
+                      isLoadingReplies={isLoadingReplies}
+                      commentId={comment.id}
+                      totalCommentsCount={comment.commentsCount.total}
+                    />
+                  )}
                 </div>
                 <Timestamp date={comment.created} />
               </div>

--- a/packages/components/modules/comments/web/CommentItem/index.tsx
+++ b/packages/components/modules/comments/web/CommentItem/index.tsx
@@ -88,14 +88,17 @@ const CommentItem: FC<CommentItemProps> = ({
   }
 
   const replyToComment = () => {
-    onReplyClick?.()
-    setCommentReply({
-      commentItemRef,
-      inReplyToId: comment.id,
-      name: comment.user?.fullName,
-    })
+    if (hasUser) {
+      onReplyClick?.()
+      setCommentReply({
+        commentItemRef,
+        inReplyToId: comment.id,
+        name: comment.user?.fullName,
+      })
+    }
     showReplies()
   }
+
   const renderUserName = () => {
     if (!hasUser) return <Typography variant="subtitle2">Deleted User</Typography>
 
@@ -171,14 +174,12 @@ const CommentItem: FC<CommentItemProps> = ({
               <div className="flex justify-between">
                 <div className="grid grid-cols-[repeat(2,max-content)] gap-4">
                   <CommentReactionButton target={comment} />
-                  {hasUser && (
-                    <CommentReplyButton
-                      onReply={replyToComment}
-                      isLoadingReplies={isLoadingReplies}
-                      commentId={comment.id}
-                      totalCommentsCount={comment.commentsCount.total}
-                    />
-                  )}
+                  <CommentReplyButton
+                    onReply={replyToComment}
+                    isLoadingReplies={isLoadingReplies}
+                    commentId={comment.id}
+                    totalCommentsCount={comment.commentsCount.total}
+                  />
                 </div>
                 <Timestamp date={comment.created} />
               </div>

--- a/packages/design-system/components/web/avatars/ClickableAvatar/index.tsx
+++ b/packages/design-system/components/web/avatars/ClickableAvatar/index.tsx
@@ -5,32 +5,44 @@ import { FC } from 'react'
 import { m } from 'framer-motion'
 
 import { varHover } from '../../animate/variants'
+import AvatarUploadFallbackIcon from '../../icons/AvatarUploadFallbackIcon'
 import AvatarWithPlaceholder from '../AvatarWithPlaceholder'
 import { IconButtonStyled } from './styled'
 import { ClickableAvatarProps } from './types'
 
 const ClickableAvatar: FC<ClickableAvatarProps> = ({
+  deletedUser = false,
   onClick,
   isOpen = false,
   width = 36,
   height = 36,
   children,
   ...props
-}) => (
-  <IconButtonStyled
-    component={m.button}
-    whileTap="tap"
-    whileHover="hover"
-    variants={varHover(1.05)}
-    onClick={onClick}
-    width={width}
-    height={height}
-    isOpen={isOpen}
-  >
-    <AvatarWithPlaceholder width={width} height={height} {...props}>
-      {children}
-    </AvatarWithPlaceholder>
-  </IconButtonStyled>
-)
+}) => {
+  if (deletedUser) {
+    return (
+      <AvatarWithPlaceholder width={width} height={height} {...props}>
+        <AvatarUploadFallbackIcon sx={{ fontSize: width }} titleAccess="Avatar Fallback" />
+      </AvatarWithPlaceholder>
+    )
+  }
+
+  return (
+    <IconButtonStyled
+      component={m.button}
+      whileTap="tap"
+      whileHover="hover"
+      variants={varHover(1.05)}
+      onClick={onClick}
+      width={width}
+      height={height}
+      isOpen={isOpen}
+    >
+      <AvatarWithPlaceholder width={width} height={height} {...props}>
+        {children}
+      </AvatarWithPlaceholder>
+    </IconButtonStyled>
+  )
+}
 
 export default ClickableAvatar

--- a/packages/design-system/components/web/avatars/ClickableAvatar/types.ts
+++ b/packages/design-system/components/web/avatars/ClickableAvatar/types.ts
@@ -7,6 +7,7 @@ export interface CustomIconButtonProps
     Required<Pick<ClickableAvatarProps, 'width' | 'height' | 'isOpen'>> {}
 
 export type ClickableAvatarProps = AvatarWithPlaceholderProps & {
+  deletedUser?: boolean
   isOpen?: boolean
   onClick?: (param: any) => void
 }


### PR DESCRIPTION
Acceptance Criteria 
As a user in the Comments Feature, I want comments from deleted users to remain visible but anonymized, so that the discussion context is preserved without exposing the deleted user’s identity.

Acceptance Criteria  

When a user deletes their account, the system should anonymize their presence in all comments they made.  

The user's name and avatar should be removed from all their comments.  

Replace the avatar with a generic "Deleted User" icon.  

Display a label such as “Deleted User” instead of their name.  

The link to the deleted user's profile should be removed from all comments.  

The content of the comment should remain visible to other users.  

Comments from deleted users should still be displayed in threads and maintain their original position in the discussion.  

Pinned comments authored by a deleted user should still display as pinned but anonymized.  

If a comment from a deleted user is replied to, the reply should still be shown normally. 

Approvd 
https://app.approvd.io/projects/BA/stories/42711 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comments and activity log entries now show “Deleted User” when the author is missing.
  * Avatars for deleted/missing users display a non-clickable placeholder icon.
  * Reply action is disabled for comments whose author no longer exists.
  * Avatar component supports a deleted-state to control fallback display and interactivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->