### PR TITLE
User Deletion - Remove User Info from Messages

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/components
 
+## 1.4.1
+
+### Patch Changes
+
+- User Deletion - Remove User Info from Messages
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/components/modules/messages/common/utils.ts
+++ b/packages/components/modules/messages/common/utils.ts
@@ -37,6 +37,13 @@ const useRoomNameAndAvatar = (headerRef: RoomTitleFragment$key | null | undefine
   const otherParticipant = header.participants.edges.find(
     (edge) => edge?.node?.profile?.id && edge?.node?.profile?.id !== currentProfile?.id,
   )
+  if (otherParticipant === undefined) {
+    return {
+      title: 'Deleted User',
+      avatar: undefined,
+    }
+  }
+
   return {
     title: otherParticipant?.node?.profile?.name,
     avatar: otherParticipant?.node?.profile?.image?.url,

--- a/packages/components/modules/messages/web/MessagesList/MessagesGroup/UserMessage/index.tsx
+++ b/packages/components/modules/messages/web/MessagesList/MessagesGroup/UserMessage/index.tsx
@@ -59,10 +59,10 @@ const UserMessage: FC<UserMessageProps> = ({
   }, [allMessages, allMessagesLastIndex, messageIndex])
 
   const isOwnMessage = currentProfile?.id === message?.profile?.id
-
+  const isProfileNull = message?.profile === null
   const flexAlignments = isOwnMessage ? 'flex-end' : 'flex-start'
-  const canShowAvatar = isFirstGroupedMessage && !isOwnMessage
 
+  const canShowAvatar = isProfileNull || (isFirstGroupedMessage && !isOwnMessage)
   const canShowName = canShowAvatar && isGroup
 
   if (!message) return null
@@ -92,7 +92,7 @@ const UserMessage: FC<UserMessageProps> = ({
       >
         {canShowName && (
           <Typography variant="subtitle2" color="text.primary" marginBottom={1 / 2}>
-            {message?.profile?.name}
+            {message?.profile?.name ?? 'Deleted User'}
           </Typography>
         )}
         <MessageItem

--- a/packages/components/modules/messages/web/MessagesList/MessagesGroup/UserMessage/index.tsx
+++ b/packages/components/modules/messages/web/MessagesList/MessagesGroup/UserMessage/index.tsx
@@ -59,10 +59,10 @@ const UserMessage: FC<UserMessageProps> = ({
   }, [allMessages, allMessagesLastIndex, messageIndex])
 
   const isOwnMessage = currentProfile?.id === message?.profile?.id
-  const isProfileNull = message?.profile === null
+  const isProfileNullOrUndefined = message?.profile == null || message?.profile === undefined
   const flexAlignments = isOwnMessage ? 'flex-end' : 'flex-start'
 
-  const canShowAvatar = isProfileNull || (isFirstGroupedMessage && !isOwnMessage)
+  const canShowAvatar = isProfileNullOrUndefined || (isFirstGroupedMessage && !isOwnMessage)
   const canShowName = canShowAvatar && isGroup
 
   if (!message) return null
@@ -92,7 +92,7 @@ const UserMessage: FC<UserMessageProps> = ({
       >
         {canShowName && (
           <Typography variant="subtitle2" color="text.primary" marginBottom={1 / 2}>
-            {message?.profile?.name ?? 'Deleted User'}
+            {isProfileNullOrUndefined ? 'Deleted User' : message?.profile?.name}
           </Typography>
         )}
         <MessageItem

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && pnpm relay && tsc --build tsconfig.build.json",


### PR DESCRIPTION
Acceptance Criteria 
As a user in the Messaging Feature, I want messages from deleted users to preserve their content but not show their name, avatar, or profile link, so that the conversation history remains readable without exposing data from deleted accounts.

Acceptance Criteria  

When a user deletes their account, the system should anonymize their presence in all chat messages they participated in.  

The user's name and avatar should be removed from all past messages.  

Replace the avatar with a generic "Deleted User" icon.  

Display a label such as “Deleted User” instead of their name.  

The link to the deleted user's profile should be removed from all messages.  

Messages sent by deleted users should remain visible to other participants in the chat.  

Group and direct chats should continue to display messages from deleted users with anonymized attribution.  

The message layout and order should remain unchanged after account deletion. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Falls back to “Deleted User” when a sender/profile is missing while preserving intentionally empty names.
  * Shows avatars for messages with an explicitly null profile and for first messages in grouped threads from others.
  * Ensures conversation headers display “Deleted User” and omit avatars when the other participant no longer exists.
  * Improves consistency across message lists and group views, reducing visual glitches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->