### PR TITLE
BA-2756: components tweaks

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @baseapp-frontend/components
 
+## 1.4.2
+
+### Patch Changes
+
+- Fix UI incosistency for the `ProfileSettingsComponent` during page refreshes.
+- Remove incorrect border showing on the AccountPopover menu when the `SwitchProfileMenu`component is `null`.
+- Allow `SwitchProfileMenu`to be `null` (useful for opting-out of that feature).
+
+
 ## 1.4.1
 
 ### Patch Changes

--- a/packages/components/modules/navigations/web/Header/AccountMenu/AccountPopover/CurrentProfileMenu/index.tsx
+++ b/packages/components/modules/navigations/web/Header/AccountMenu/AccountPopover/CurrentProfileMenu/index.tsx
@@ -23,11 +23,9 @@ const CurrentProfileMenu: FC<CurrentProfileMenuProps> = ({
   setOpenProfilesList,
 }) => {
   const { currentProfile: profile } = useCurrentProfile()
-  const loadCurrentProfile = Boolean(CurrentProfile) && Boolean(profile)
-  const loadCurrentUser = !loadCurrentProfile && Boolean(CurrentUser)
-  const shouldShowDivider = Boolean(
-    loadCurrentProfile || loadCurrentUser || Boolean(SwitchProfileMenu),
-  )
+  const loadCurrentProfile = !!CurrentProfile && !!profile
+  const loadCurrentUser = !loadCurrentProfile && !!CurrentUser
+  const shouldShowDivider = (loadCurrentProfile || loadCurrentUser) && !!SwitchProfileMenu
 
   return (
     <>
@@ -35,14 +33,14 @@ const CurrentProfileMenu: FC<CurrentProfileMenuProps> = ({
 
       {loadCurrentUser && <CurrentUser />}
 
-      {loadCurrentProfile && Boolean(SwitchProfileMenu) && (
+      {loadCurrentProfile && !!SwitchProfileMenu && (
         <SwitchProfileMenu
           openProfilesList={() => setOpenProfilesList(true)}
           {...SwitchProfileMenuProps}
         />
       )}
 
-      {Boolean(MenuItemsProps?.menuItems?.length) && (
+      {!!MenuItemsProps?.menuItems?.length && (
         <>
           {shouldShowDivider && <Divider sx={{ borderStyle: 'solid' }} />}
 

--- a/packages/components/modules/navigations/web/Header/AccountMenu/AccountPopover/CurrentProfileMenu/types.ts
+++ b/packages/components/modules/navigations/web/Header/AccountMenu/AccountPopover/CurrentProfileMenu/types.ts
@@ -8,7 +8,7 @@ export interface CurrentProfileMenuProps {
   CurrentProfile?: FC
   MenuItems?: FC<MenuItemsProps>
   MenuItemsProps?: Partial<MenuItemsProps>
-  SwitchProfileMenu?: FC<SwitchProfileMenuProps>
+  SwitchProfileMenu?: FC<SwitchProfileMenuProps> | null
   SwitchProfileMenuProps?: Partial<SwitchProfileMenuProps>
   handlePopoverOnClose: () => void
   setOpenProfilesList: (open: boolean) => void

--- a/packages/components/modules/profiles/web/ProfileSettingsComponent/index.tsx
+++ b/packages/components/modules/profiles/web/ProfileSettingsComponent/index.tsx
@@ -126,7 +126,7 @@ const ProfileSettingsComponent: FC<ProfileSettingsComponentProps> = ({ profile: 
   }
 
   return (
-    <Card>
+    <Card sx={{ maxWidth: '600px' }}>
       <CardContent>
         <form
           // @ts-ignore TODO: check typing issue with zodResolver

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && pnpm relay && tsc --build tsconfig.build.json",


### PR DESCRIPTION
- `components` package update - `v 1.4.2`
  - Fix UI incosistency for the `ProfileSettingsComponent` during page refreshes.
  - Remove incorrect border showing on the AccountPopover menu when the `SwitchProfileMenu`component is `null`.
  - Allow `SwitchProfileMenu`to be `null` (useful for opting-out of that feature).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added ability to disable the Switch Profile menu, allowing users to opt out.

- Bug Fixes
  - Resolved UI inconsistency in Profile Settings during page refreshes.
  - Removed an incorrect border in the account popover when the Switch Profile menu is disabled.
  - Refined divider visibility in the account popover for cleaner presentation.

- Style
  - Limited the Profile Settings layout width for improved readability.

- Chores
  - Bumped components package version to 1.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->