### PR TITLE
BA-2778: load client cookies as initial data

### DIFF
--- a/packages/authentication/CHANGELOG.md
+++ b/packages/authentication/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @baseapp-frontend/authentication
 
+## 5.0.4
+
+### Patch Changes
+
+- Enhanced current profile store to automatically load profile from client-side cookies when no initial profile is provided
+- Updated dependencies
+  - @baseapp-frontend/utils@4.0.3
+
 ## 5.0.3
 
 ### Patch Changes

--- a/packages/authentication/modules/profile/useCurrentProfile/store.ts
+++ b/packages/authentication/modules/profile/useCurrentProfile/store.ts
@@ -7,11 +7,26 @@ import type { CurrentProfileState } from './types'
 
 let profileStore: StoreApi<CurrentProfileState> | null = null
 
+const getClientSideCurrentProfile = (): MinimalProfile | null => {
+  const storedProfile = Cookies.get(CURRENT_PROFILE_KEY_NAME)
+  if (storedProfile) {
+    try {
+      return JSON.parse(storedProfile)
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
 const createProfileStore = (
-  initialProfile: MinimalProfile | null = null,
-): StoreApi<CurrentProfileState> =>
-  createStore<CurrentProfileState>()((set) => ({
-    currentProfile: initialProfile,
+  initialProfile?: MinimalProfile | null,
+): StoreApi<CurrentProfileState> => {
+  // If no initialProfile provided, try to get it from client-side cookies
+  const profileToUse = initialProfile || getClientSideCurrentProfile()
+
+  return createStore<CurrentProfileState>()((set) => ({
+    currentProfile: profileToUse,
     setCurrentProfile: (profile: MinimalProfile | null) => {
       Cookies.set(CURRENT_PROFILE_KEY_NAME, JSON.stringify(profile))
       set(() => ({ currentProfile: profile }))
@@ -26,6 +41,7 @@ const createProfileStore = (
       })
     },
   }))
+}
 
 export const initializeProfileStore = (
   initialProfile: MinimalProfile | null = null,
@@ -37,7 +53,6 @@ export const initializeProfileStore = (
     (initialProfile && Object.keys(initialProfile).length > 0)
   ) {
     profileStore = createProfileStore(initialProfile)
-    return profileStore
   }
 
   return profileStore

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/authentication",
   "description": "Authentication modules.",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @baseapp-frontend/components
 
+## 1.4.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/authentication@5.0.4
+  - @baseapp-frontend/design-system@1.1.2
+  - @baseapp-frontend/utils@4.0.3
+  - @baseapp-frontend/graphql@1.3.5
+
 ## 1.4.3
 
 ### Patch Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && pnpm relay && tsc --build tsconfig.build.json",

--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @baseapp-frontend/design-system
 
+## 1.1.2
+
+### Patch Changes
+
+- Enhanced UI settings store to automatically load settings from client-side cookies when no initial settings are provided
+- Updated dependencies
+  - @baseapp-frontend/utils@4.0.3
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/design-system/hooks/web/useUISettings/index.tsx
+++ b/packages/design-system/hooks/web/useUISettings/index.tsx
@@ -5,7 +5,7 @@ import { createContext, useContext, useEffect, useRef } from 'react'
 import { type StoreApi, useStore } from 'zustand'
 
 import { Palette, PresetType, getPresetOptions } from '../../../styles/web'
-import { DEFAULT_UI_SETTINGS, MISSING_UI_SETTINGS_STORE_ERROR } from './constants'
+import { MISSING_UI_SETTINGS_STORE_ERROR } from './constants'
 import { initializeSettingsStore } from './store'
 import type { UISettingsProviderProps, UISettingsState } from './types'
 
@@ -35,8 +35,7 @@ export const UISettingsProvider = ({
   const storeRef = useRef<StoreApi<UISettingsState>>(undefined)
 
   if (!storeRef.current) {
-    const initialSettings = initialUISettings || DEFAULT_UI_SETTINGS
-    storeRef.current = initializeSettingsStore(initialSettings)
+    storeRef.current = initializeSettingsStore(initialUISettings)
   }
 
   const store = storeRef.current

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/design-system",
   "description": "Design System components and configurations.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && tsc --build tsconfig.build.json",

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @baseapp-frontend/graphql
 
+## 1.3.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/authentication@5.0.4
+  - @baseapp-frontend/utils@4.0.3
+
 ## 1.3.4
 
 ### Patch Changes

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/graphql",
   "description": "GraphQL configurations and utilities",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/provider/CHANGELOG.md
+++ b/packages/provider/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/provider
 
+## 2.0.17
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/utils@4.0.3
+
 ## 2.0.16
 
 ### Patch Changes

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/provider",
   "description": "Providers for React Query and Emotion.",
-  "version": "2.0.16",
+  "version": "2.0.17",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/utils
 
+## 4.0.3
+
+### Patch Changes
+
+- Enhanced cookie store to automatically load cookies from client-side when no initial cookies are provided
+
 ## 4.0.2
 
 ### Patch Changes

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/utils",
   "description": "Util functions, constants and types.",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/wagtail/CHANGELOG.md
+++ b/packages/wagtail/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @baseapp-frontend/wagtail
 
+## 1.0.39
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/design-system@1.1.2
+  - @baseapp-frontend/utils@4.0.3
+  - @baseapp-frontend/graphql@1.3.5
+
 ## 1.0.38
 
 ### Patch Changes

--- a/packages/wagtail/package.json
+++ b/packages/wagtail/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/wagtail",
   "description": "BaseApp Wagtail",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
- `design-system` package update - `v 1.1.2`
  - Enhanced UI settings store to automatically load settings from client-side cookies when no initial settings are provided
 
- `authentication` package update - `v 5.0.4`
  - Enhanced current profile store to automatically load profile from client-side cookies when no initial profile is provided

- `utils` package update - `v 4.0.3`
  - Enhanced cookie store to automatically load cookies from client-side when no initial cookies are provided


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically load the current profile from browser cookies when none is provided.
  - UI settings now auto-load from cookies and persist updates, ensuring preferences (e.g., theme) apply consistently.
  - Improved client-side cookie handling for more reliable defaults.

- Chores
  - Updated internal dependencies across packages for compatibility and stability.
  - Version bumps for authentication, components, design-system, graphql, provider, utils, and wagtail packages.

- Documentation
  - Changelogs updated to reflect the above enhancements and dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->