### PR TITLE
BA-2847-FE-prevent-self-blocking-and-reporting

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/components
 
+## 1.4.5
+
+### Patch Changes
+
+- Hide block and report buttons for own profile, to prevent self-blocking and reporting
+
 ## 1.4.4
 
 ### Patch Changes

--- a/packages/components/modules/profiles/web/ProfileComponent/index.tsx
+++ b/packages/components/modules/profiles/web/ProfileComponent/index.tsx
@@ -110,7 +110,7 @@ const ProfileComponent: FC<ProfileComponentProps> = ({ profile: profileRef, curr
         Share profile
       </MenuItem>
       {smDown && <Divider />}
-      {profile && (
+      {profile && currentProfileId !== profile?.id && (
         <>
           <BlockButtonWithDialog
             target={profile}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && pnpm relay && tsc --build tsconfig.build.json",


### PR DESCRIPTION
- `__package_name__` package update - `v __package_version__`
  - **changelog_info**
  - **changelog_info**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile menu now hides block and report actions when viewing your own profile; those actions remain available on other users' profiles. Share and divider options unchanged.

* **Chores**
  * Package version bumped to v1.4.5 and changelog updated to document the UI change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->