### PR TITLE
hotfix/BA-2901-fix-posts-image-distortion-to-fit-space

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/components
 
+## 1.4.8
+
+### Patch Changes
+
+- Fix for posts images being deformed if too big
+
 ## 1.4.7
 
 ### Patch Changes

--- a/packages/components/modules/content-feed/web/PostImageSlide/styled.tsx
+++ b/packages/components/modules/content-feed/web/PostImageSlide/styled.tsx
@@ -2,5 +2,7 @@ import { styled } from '@mui/material'
 
 export const ImageSlide = styled('img')(() => ({
   height: '100%',
+  width: '100%',
+  objectFit: 'contain',
   userSelect: 'none',
 }))

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && pnpm relay && tsc --build tsconfig.build.json",


### PR DESCRIPTION
[BA-2900](https://silverlogic.atlassian.net/browse/BA-2900) ✅ The image is stretching vertically, leading to a poor visual presentation
Key details
Description

Acceptance Criteria 
Steps to Reproduce:

    Login in baseapp,

    Navigate to localhosts:3000/posts

    Upload some images, add content and publish the posts.

Actual Result:

    The image is stretching vertically, leading to a poor visual presentation

Expected Result:

    Image resolution should maintain proper aspect ratio.

Loom:  https://www.loom.com/share/a19a917bd80b49389e6a4bc7a6e64e80 

Approvd 
https://app.approvd.io/silverlogic/BA/stories/42093

[BA-2900]: https://silverlogic.atlassian.net/browse/BA-2900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Fix screenshot:
<img width="2908" height="1850" alt="Screenshot 2025-12-03 at 17 48 58" src="https://github.com/user-attachments/assets/5f3949c6-a51b-43e1-b3ef-d4005945c129" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fix for post images deforming when large — images now maintain correct aspect ratio and fit within the post layout.
* **Style**
  * Improved image sizing and selection behavior in the content feed for more consistent display.
* **Documentation**
  * Added changelog entry for version 1.4.8.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->