### PR TITLE
hotfix: exclude dist/ and schemas from relay compiler

### DIFF
--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/config
 
+## 2.1.14
+
+### Patch Changes
+
+- hotfix: exclude dist/ and schemas from relay compiler
+
 ## 2.1.13
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/config",
   "description": "Reusable configurations for eslint, prettier, jest and relay",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "files": [
     ".eslintrc.js",
     ".eslintrc-with-restricted-paths.js",

--- a/packages/config/relay.config.ts
+++ b/packages/config/relay.config.ts
@@ -7,6 +7,8 @@ module.exports = {
     '**/__generated__/**',
     '**/.app-templates/**',
     '**/cypress/**',
+    '**/dist/**', // Exclude built artifacts
+    '**/schema.graphql', // Exclude schemas
   ],
   language: 'typescript',
   artifactDirectory: './__generated__',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bumped to 2.1.14
  * Updated build configuration to optimize the relay compiler by excluding unnecessary build artifacts and schema files from processing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->