### PR TITLE
exclude out/ next.js build output from relay.config.js

### DIFF
--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/config
 
+## 2.1.15
+
+### Patch Changes
+
+- exclude out/ Next.js build output from relay.config.js
+
 ## 2.1.14
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/config",
   "description": "Reusable configurations for eslint, prettier, jest and relay",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "files": [
     ".eslintrc.js",
     ".eslintrc-with-restricted-paths.js",

--- a/packages/config/relay.config.ts
+++ b/packages/config/relay.config.ts
@@ -9,6 +9,7 @@ module.exports = {
     '**/cypress/**',
     '**/dist/**', // Exclude built artifacts
     '**/schema.graphql', // Exclude schemas
+    'out/**',
   ],
   language: 'typescript',
   artifactDirectory: './__generated__',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version update (2.1.15) with configuration optimization to exclude Next.js build artifacts from processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->