### PR TITLE
Add VerticalDrawer component and its types to navigation module

### DIFF
--- a/packages/components/modules/navigations/web/index.ts
+++ b/packages/components/modules/navigations/web/index.ts
@@ -28,5 +28,8 @@ export type * from './Header/AccountMenu/AccountPopover/types'
 export { default as ViewportHeightContainer } from './ViewportHeightContainer'
 export type * from './ViewportHeightContainer/types'
 
+export { default as VerticalDrawer } from './__shared__/VerticalDrawer'
+export type * from './__shared__/VerticalDrawer/types'
+
 export * from './constants'
 export type * from './types'


### PR DESCRIPTION
Exporting VerticalDrawer so we could use it alone, this was necessary in one of our projects and I think should cause no harm to BA.

In our case we kinda have 2 different layouts on the same app so we had to call the drawer on mobile on the layout that is not the one we chosse during statup.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VerticalDrawer component is now available as a public export, providing an additional navigation option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->