### PR TITLE
feature/HIVE-54: fix profile component infinite loop and more

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @baseapp-frontend/components
 
+## 1.5.11
+
+### Patch Changes
+
+- Fixed infinite loop issue in `ProfileComponent`, added border prop to `AvatarWithPlaceholder` component
+- Updated dependencies
+  - @baseapp-frontend/design-system@1.2.6
+
 ## 1.5.10
 
 ### Patch Changes

--- a/packages/components/modules/profiles/web/ProfileComponent/index.tsx
+++ b/packages/components/modules/profiles/web/ProfileComponent/index.tsx
@@ -31,7 +31,11 @@ import {
 } from './styled'
 import { ProfileComponentProps } from './types'
 
-const ProfileComponent: FC<ProfileComponentProps> = ({ profile: profileRef, currentProfileId }) => {
+const ProfileComponent: FC<ProfileComponentProps> = ({
+  profile: profileRef,
+  currentProfileId,
+  bannerFallback = '/png/profile-banner-fallback.png',
+}) => {
   const profile = useFragment(ProfileComponentFragment, profileRef)
   const smDown = useResponsive('down', 'sm')
   const router = useRouter()
@@ -123,12 +127,14 @@ const ProfileComponent: FC<ProfileComponentProps> = ({ profile: profileRef, curr
     ),
   ].filter(Boolean)
 
+  const bannerSrc = profile?.bannerImage?.url || bannerFallback
+
   return (
     <div className="flex h-full w-full justify-center">
       <ProfileContainer>
         <ImageWithFallback
-          src={profile?.bannerImage?.url || '/png/profile-banner-fallback.png'}
-          fallbackSrc="/png/profile-banner-fallback.png"
+          src={bannerSrc}
+          fallbackSrc={bannerFallback}
           alt="Home Banner"
           width={868}
           height={

--- a/packages/components/modules/profiles/web/ProfileComponent/index.tsx
+++ b/packages/components/modules/profiles/web/ProfileComponent/index.tsx
@@ -103,37 +103,36 @@ const ProfileComponent: FC<ProfileComponentProps> = ({ profile: profileRef, curr
     )
   }
 
-  const menuOptions = (
-    <>
-      <MenuItem onClick={handleShareClick} disableRipple>
-        <ShareIcon />
-        Share profile
-      </MenuItem>
-      {smDown && <Divider />}
-      {profile && currentProfileId !== profile?.id && (
-        <>
-          <BlockButtonWithDialog
-            target={profile}
-            handleCloseMenu={handleClose}
-            currentProfileId={currentProfileId}
-            isMenu
-          />
-          <ReportButtonWithDialog handleClose={handleClose} targetId={profile?.id} />
-        </>
-      )}
-    </>
-  )
+  const menuOptions = [
+    <MenuItem key="share" onClick={handleShareClick} disableRipple>
+      <ShareIcon />
+      Share profile
+    </MenuItem>,
+    smDown && <Divider key="divider" />,
+    profile && currentProfileId !== profile?.id && (
+      <BlockButtonWithDialog
+        key="block"
+        target={profile}
+        handleCloseMenu={handleClose}
+        currentProfileId={currentProfileId}
+        isMenu
+      />
+    ),
+    profile && currentProfileId !== profile?.id && (
+      <ReportButtonWithDialog key="report" handleClose={handleClose} targetId={profile?.id} />
+    ),
+  ].filter(Boolean)
 
   return (
     <div className="flex h-full w-full justify-center">
       <ProfileContainer>
         <ImageWithFallback
-          src={profile?.bannerImage?.url ?? ''}
+          src={profile?.bannerImage?.url || '/png/profile-banner-fallback.png'}
           fallbackSrc="/png/profile-banner-fallback.png"
           alt="Home Banner"
           width={868}
           height={
-            290 /* Some css height: auto takes precedence, 
+            290 /* Some css height: auto takes precedence,
             so also set as style below */
           }
           className="overflow-hidden rounded-lg"

--- a/packages/components/modules/profiles/web/ProfileComponent/types.ts
+++ b/packages/components/modules/profiles/web/ProfileComponent/types.ts
@@ -1,6 +1,6 @@
 import { ProfileComponentFragment$key } from '../../../../__generated__/ProfileComponentFragment.graphql'
 
 export interface ProfileComponentProps {
-  profile?: ProfileComponentFragment$key | null
+  profile: ProfileComponentFragment$key
   currentProfileId?: string
 }

--- a/packages/components/modules/profiles/web/ProfileComponent/types.ts
+++ b/packages/components/modules/profiles/web/ProfileComponent/types.ts
@@ -3,4 +3,5 @@ import { ProfileComponentFragment$key } from '../../../../__generated__/ProfileC
 export interface ProfileComponentProps {
   profile: ProfileComponentFragment$key
   currentProfileId?: string
+  bannerFallback?: string
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && pnpm relay && tsc --build tsconfig.build.json",

--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/design-system
 
+## 1.2.6
+
+### Patch Changes
+
+- Fixed infinite loop issue in `ProfileComponent`, added border prop to `AvatarWithPlaceholder` component
+
 ## 1.2.5
 
 ### Patch Changes

--- a/packages/design-system/components/web/avatars/AvatarWithPlaceholder/index.tsx
+++ b/packages/design-system/components/web/avatars/AvatarWithPlaceholder/index.tsx
@@ -8,12 +8,21 @@ import { AvatarWithPlaceholderProps } from './types'
 const AvatarWithPlaceholder: FC<AvatarWithPlaceholderProps> = ({
   width = 40,
   height = 40,
+  borderStyle = 'solid',
+  borderWidth = '2px',
   children,
   alt,
   showDeletedUser = false,
   ...props
 }) => (
-  <AvatarStyled width={width} height={height} alt={alt} {...props}>
+  <AvatarStyled
+    width={width}
+    height={height}
+    alt={alt}
+    borderStyle={borderStyle}
+    borderWidth={borderWidth}
+    {...props}
+  >
     {children ||
       (showDeletedUser ? (
         <AvatarDeletedUserIcon sx={{ fontSize: width }} titleAccess="Deleted User Avatar" />

--- a/packages/design-system/components/web/avatars/AvatarWithPlaceholder/styled.tsx
+++ b/packages/design-system/components/web/avatars/AvatarWithPlaceholder/styled.tsx
@@ -10,9 +10,9 @@ import { AvatarWithPlaceholderProps } from './types'
 
 export const AvatarStyled: ComponentType<AvatarWithPlaceholderProps> = styled(
   Avatar,
-)<AvatarWithPlaceholderProps>(({ theme, width, height }) => ({
+)<AvatarWithPlaceholderProps>(({ theme, width, height, borderStyle, borderWidth }) => ({
   width,
   height,
-  border: `solid 2px ${theme.palette.background.default}`,
+  border: `${borderStyle} ${borderWidth} ${theme.palette.background.default}`,
   backgroundColor: theme.palette.grey[300],
 })) as OverridableComponent<AvatarTypeMap<AvatarWithPlaceholderProps, 'div'>>

--- a/packages/design-system/components/web/avatars/AvatarWithPlaceholder/types.ts
+++ b/packages/design-system/components/web/avatars/AvatarWithPlaceholder/types.ts
@@ -3,5 +3,7 @@ import { AvatarProps } from '@mui/material'
 export interface AvatarWithPlaceholderProps extends AvatarProps {
   width?: number
   height?: number
+  borderStyle?: 'solid' | 'dashed' | 'dotted'
+  borderWidth?: string
   showDeletedUser?: boolean
 }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/design-system",
   "description": "Design System components and configurations.",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && tsc --build tsconfig.build.json",

--- a/packages/wagtail/CHANGELOG.md
+++ b/packages/wagtail/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/wagtail
 
+## 1.0.52
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/design-system@1.2.6
+
 ## 1.0.51
 
 ### Patch Changes

--- a/packages/wagtail/package.json
+++ b/packages/wagtail/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/wagtail",
   "description": "BaseApp Wagtail",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
- Fixes infinite loop call to `__nextjs_original-stack-frames` when accessing the profile page
- Allows editing border properties on `AvatarWithPlaceholder` component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Avatar supports customizable border style and width.
  * Image component now provides a default banner fallback.

* **Bug Fixes**
  * Profile banner fallback updated to always supply a valid image URL.

* **Refactor**
  * Profile menu options consolidated into a stable, centrally managed list with conditional entries.
  * Profile prop changed to be required to simplify component usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->