### PR TITLE
Make sure notifications subscriptions don't mismatch

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/components
 
+## 1.5.20
+
+### Patch Changes
+
+- Make notifications subscription customizable
+- Fix duplicate Older divider when mark as read
+
 ## 1.5.19
 
 ### Patch Changes

--- a/packages/components/modules/notifications/web/NotificationsList/NotificationItem/index.tsx
+++ b/packages/components/modules/notifications/web/NotificationsList/NotificationItem/index.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, startTransition } from 'react'
 
 import { Box } from '@mui/material'
 import { useFragment } from 'react-relay'
@@ -9,6 +9,7 @@ import { NotificationItemProps } from './types'
 
 const NotificationItem: FC<NotificationItemProps> = ({
   notification: notificationRef,
+  refetchNotifications,
   NotificationItemRenderer = DefaultNotificationItemRenderer,
   NotificationItemRendererProps = {},
 }) => {
@@ -24,6 +25,11 @@ const NotificationItem: FC<NotificationItemProps> = ({
             read: true,
             notificationIds: [notification.id],
           },
+        },
+        onCompleted: () => {
+          startTransition(() => {
+            refetchNotifications?.()
+          })
         },
       })
     }

--- a/packages/components/modules/notifications/web/NotificationsList/NotificationItem/types.ts
+++ b/packages/components/modules/notifications/web/NotificationsList/NotificationItem/types.ts
@@ -5,6 +5,7 @@ import { NotificationItemRendererProps } from './NotificationItemRenderer/types'
 
 export interface NotificationItemProps {
   notification: NotificationItemFragment$key
+  refetchNotifications?: () => void
   NotificationItemRenderer?: FC<NotificationItemRendererProps>
   NotificationItemRendererProps?: Partial<NotificationItemRendererProps>
 }

--- a/packages/components/modules/notifications/web/NotificationsList/index.tsx
+++ b/packages/components/modules/notifications/web/NotificationsList/index.tsx
@@ -53,6 +53,10 @@ const NotificationsList: FC<NotificationsListProps> = ({
     [data?.notifications?.edges],
   )
 
+  const refetchNotifications = () => {
+    refetch(options, { fetchPolicy: 'network-only' })
+  }
+
   const renderNotificationItem = (notification: any, index: number) => {
     if (!notification) return null
     if (!notification.unread && notifications[index - 1]?.unread) {
@@ -64,6 +68,7 @@ const NotificationsList: FC<NotificationsListProps> = ({
           <NotificationItem
             key={`notification-${notification.id}`}
             notification={notification}
+            refetchNotifications={refetchNotifications}
             {...NotificationItemProps}
           />
         </>
@@ -73,6 +78,7 @@ const NotificationsList: FC<NotificationsListProps> = ({
       <NotificationItem
         key={`notification-${notification.id}`}
         notification={notification}
+        refetchNotifications={refetchNotifications}
         {...NotificationItemProps}
       />
     )
@@ -115,10 +121,6 @@ const NotificationsList: FC<NotificationsListProps> = ({
         />
       </ListContainer>
     )
-  }
-
-  const refetchNotifications = () => {
-    refetch(options, { fetchPolicy: 'network-only' })
   }
 
   return (

--- a/packages/components/modules/notifications/web/NotificationsList/index.tsx
+++ b/packages/components/modules/notifications/web/NotificationsList/index.tsx
@@ -15,7 +15,6 @@ import {
   NUMBER_OF_NOTIFICATIONS_TO_LOAD_NEXT,
   NotificationsListFragment,
   NotificationsListQuery,
-  useNotificationsSubscription,
 } from '../../common'
 import DefaultEmptyState from './EmptyState'
 import MarkAllAsReadButton from './MarkAllAsReadButton'
@@ -48,8 +47,6 @@ const NotificationsList: FC<NotificationsListProps> = ({
     NotificationsListQueryType,
     NotificationsListFragment$key
   >(NotificationsListFragment, me)
-
-  useNotificationsSubscription(me?.id)
 
   const notifications = useMemo(
     () => data?.notifications?.edges.filter((edge) => edge?.node).map((edge) => edge?.node) || [],

--- a/packages/components/modules/notifications/web/NotificationsPopover/index.tsx
+++ b/packages/components/modules/notifications/web/NotificationsPopover/index.tsx
@@ -22,9 +22,9 @@ import { NotificationUserMenuFragment$key } from '../../../../__generated__/Noti
 import { NotificationsPopoverQuery as NotificationsPopoverQueryType } from '../../../../__generated__/NotificationsPopoverQuery.graphql'
 import { NAV_WIDTH } from '../../../navigations/web/constants'
 import {
+  useNotificationsSubscription as DefaultUseNotificationsSubscription,
   NotificationUserMenuFragment,
   NotificationsPopoverQuery,
-  useNotificationsSubscription,
 } from '../../common'
 import DefaultNotificationsList from '../NotificationsList'
 import { NotificationsPopoverProps } from './types'
@@ -38,6 +38,7 @@ const NotificationsPopover: FC<NotificationsPopoverProps> = ({
   NotificationBellIconProps = {},
   NotificationsList = DefaultNotificationsList,
   NotificationsListProps = {},
+  useNotificationsSubscription = DefaultUseNotificationsSubscription,
   showLabel = false,
   currentLayout,
   labelComponent,
@@ -52,7 +53,7 @@ const NotificationsPopover: FC<NotificationsPopoverProps> = ({
 
   const user = useFragment<NotificationUserMenuFragment$key>(NotificationUserMenuFragment, me)
 
-  useNotificationsSubscription(user?.id)
+  useNotificationsSubscription(user?.id || '')
 
   const smDown = useResponsive('down', 'sm')
   const { onClose, anchor: anchorOverride, sx: sxOverride, ...restDrawerProps } = DrawerProps
@@ -155,7 +156,7 @@ const NotificationsPopover: FC<NotificationsPopoverProps> = ({
         }}
         {...restDrawerProps}
       >
-        <NotificationsList setIsDrawerOpened={setIsDrawerOpened} {...NotificationsListProps} />
+        <NotificationsList {...NotificationsListProps} setIsDrawerOpened={setIsDrawerOpened} />
       </Drawer>
     </>
   )

--- a/packages/components/modules/notifications/web/NotificationsPopover/types.ts
+++ b/packages/components/modules/notifications/web/NotificationsPopover/types.ts
@@ -13,6 +13,7 @@ export interface NotificationsPopoverProps {
   NotificationBellIconProps?: Partial<SvgIconProps>
   NotificationsList?: FC<NotificationsListProps>
   NotificationsListProps?: Partial<NotificationsListProps>
+  useNotificationsSubscription?: (userId: string) => void
   showLabel?: boolean
   labelComponent?: React.ReactNode
   currentLayout?: 'vertical' | 'mini' | 'horizontal' | 'centered'

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.5.19",
+  "version": "1.5.20",
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && pnpm relay && tsc --build tsconfig.build.json",


### PR DESCRIPTION
- `__package_name__` package update - `v __package_version__`
  - **changelog_info**
  - **changelog_info**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized how notification updates are handled to centralize refetch behavior for list items and improve update flow.

* **New Features**
  * Added an optional hook point to customize notification subscription behavior.

* **Bug Fixes**
  * Fixes duplicate "Older" divider when marking notifications as read and ensures the list refreshes smoothly after read actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->