### PR TITLE
Add header center component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/components
 
+## 1.5.21
+
+### Patch Changes
+
+- Add Extra Centered Header component
+
 ## 1.5.20
 
 ### Patch Changes

--- a/packages/components/modules/navigations/web/Header/index.tsx
+++ b/packages/components/modules/navigations/web/Header/index.tsx
@@ -6,11 +6,12 @@ import { MenuIcon } from '@baseapp-frontend/design-system/components/web/icons'
 import { Logo } from '@baseapp-frontend/design-system/components/web/logos'
 import { useUISettings } from '@baseapp-frontend/design-system/hooks/web'
 
+import Box from '@mui/material/Box'
 import IconButton from '@mui/material/IconButton'
 import Toolbar from '@mui/material/Toolbar'
 
 import DefaultAccountMenu from './AccountMenu'
-import { CustomAppBar } from './styled'
+import { CustomAppBar, HeaderCenterContainer as DefaultHeaderCenterContainer } from './styled'
 import { HeaderProps } from './types'
 
 const Header: FC<HeaderProps> = ({
@@ -20,12 +21,30 @@ const Header: FC<HeaderProps> = ({
   LogoProps,
   AccountMenu = DefaultAccountMenu,
   AccountMenuProps,
+  HeaderCenterComponent,
   ToolbarProps,
   CustomAppBarProps = {},
+  HeaderCenterContainer = DefaultHeaderCenterContainer,
 }) => {
   const { settings } = useUISettings()
   const isNavHorizontal = settings.themeLayout === 'horizontal'
   const isNavCentered = settings.themeLayout === 'centered'
+
+  const renderAccountMenu = () => {
+    // If the layout is centered, we render the AccountMenu in the header. We might want to figure out a better way to handle this in the future once we define designs for this extra component.
+    if (HeaderCenterComponent && !isNavCentered) {
+      return (
+        <>
+          <HeaderCenterContainer>{HeaderCenterComponent}</HeaderCenterContainer>
+          <Box sx={{ flexShrink: 0 }}>
+            <AccountMenu {...AccountMenuProps}>{children}</AccountMenu>
+          </Box>
+        </>
+      )
+    }
+
+    return <AccountMenu {...AccountMenuProps}>{children}</AccountMenu>
+  }
 
   return (
     <CustomAppBar {...CustomAppBarProps} themeLayout={settings.themeLayout}>
@@ -60,7 +79,7 @@ const Header: FC<HeaderProps> = ({
         >
           <MenuIcon />
         </IconButton>
-        <AccountMenu {...AccountMenuProps}>{children}</AccountMenu>
+        {renderAccountMenu()}
       </Toolbar>
     </CustomAppBar>
   )

--- a/packages/components/modules/navigations/web/Header/styled.tsx
+++ b/packages/components/modules/navigations/web/Header/styled.tsx
@@ -1,6 +1,6 @@
 import { bgBlur } from '@baseapp-frontend/design-system/styles/web'
 
-import { AppBar } from '@mui/material'
+import { AppBar, Box } from '@mui/material'
 import { styled } from '@mui/material/styles'
 
 import { HEADER_HEIGHT, NAV_WIDTH } from '../constants'
@@ -39,3 +39,11 @@ export const CustomAppBar = styled(AppBar)<CustomAppBarProps>(({ theme, themeLay
     },
   }
 })
+
+export const HeaderCenterContainer = styled(Box)(() => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flex: 1,
+  minWidth: 0,
+}))

--- a/packages/components/modules/navigations/web/Header/types.ts
+++ b/packages/components/modules/navigations/web/Header/types.ts
@@ -1,9 +1,10 @@
-import { FC, PropsWithChildren } from 'react'
+import { FC, PropsWithChildren, ReactNode } from 'react'
 
 import { PartialLogoProps } from '@baseapp-frontend/design-system/components/web/logos'
 import { ThemeLayout } from '@baseapp-frontend/design-system/styles/web'
 
 import { AppBarProps, ToolbarProps as MuiToolbarProps } from '@mui/material'
+import { BoxProps } from '@mui/system'
 
 import { AccountMenuProps } from './AccountMenu/types'
 
@@ -17,6 +18,8 @@ export interface HeaderProps extends PropsWithChildren {
   LogoProps?: PartialLogoProps
   AccountMenu?: FC<AccountMenuProps>
   AccountMenuProps?: Partial<AccountMenuProps>
+  HeaderCenterComponent?: ReactNode | null
   ToolbarProps?: MuiToolbarProps
   CustomAppBarProps?: Partial<CustomAppBarProps>
+  HeaderCenterContainer?: FC<BoxProps>
 }

--- a/packages/components/modules/navigations/web/NavigationLayout/index.tsx
+++ b/packages/components/modules/navigations/web/NavigationLayout/index.tsx
@@ -21,6 +21,7 @@ const NavigationLayout: FC<NavigationLayoutProps> = ({
   LogoProps,
   AccountMenu,
   AccountMenuProps,
+  HeaderCenterComponent,
   NavAccountSection,
   NavAccountSectionProps,
   NotificationsPopover,
@@ -60,6 +61,7 @@ const NavigationLayout: FC<NavigationLayoutProps> = ({
               ...AccountMenuProps,
               additionalComponent: notificationsComponent ?? AccountMenuProps?.additionalComponent,
             }}
+            HeaderCenterComponent={HeaderCenterComponent}
             ToolbarProps={ToolbarProps}
             CustomAppBarProps={CustomAppBarProps}
           >
@@ -92,6 +94,7 @@ const NavigationLayout: FC<NavigationLayoutProps> = ({
               ...AccountMenuProps,
               additionalComponent: notificationsComponent ?? AccountMenuProps?.additionalComponent,
             }}
+            HeaderCenterComponent={HeaderCenterComponent}
             ToolbarProps={ToolbarProps}
             CustomAppBarProps={CustomAppBarProps}
           />
@@ -123,6 +126,7 @@ const NavigationLayout: FC<NavigationLayoutProps> = ({
               ...AccountMenuProps,
               additionalComponent: notificationsComponent ?? AccountMenuProps?.additionalComponent,
             }}
+            HeaderCenterComponent={HeaderCenterComponent}
             ToolbarProps={ToolbarProps}
             CustomAppBarProps={CustomAppBarProps}
           />
@@ -171,6 +175,7 @@ const NavigationLayout: FC<NavigationLayoutProps> = ({
             ...AccountMenuProps,
             additionalComponent: notificationsComponent ?? AccountMenuProps?.additionalComponent,
           }}
+          HeaderCenterComponent={HeaderCenterComponent}
           ToolbarProps={ToolbarProps}
           CustomAppBarProps={CustomAppBarProps}
         />

--- a/packages/components/modules/navigations/web/NavigationLayout/types.ts
+++ b/packages/components/modules/navigations/web/NavigationLayout/types.ts
@@ -1,4 +1,4 @@
-import { FC, PropsWithChildren } from 'react'
+import { FC, PropsWithChildren, ReactNode } from 'react'
 
 import { PartialLogoProps } from '@baseapp-frontend/design-system/components/web/logos'
 
@@ -18,6 +18,7 @@ export interface NavigationLayoutProps extends PropsWithChildren {
   LogoProps?: PartialLogoProps
   AccountMenu?: FC<AccountMenuProps>
   AccountMenuProps?: Partial<AccountMenuProps>
+  HeaderCenterComponent?: ReactNode
   NavAccountSection?: FC<NavAccountSectionProps> | null
   NavAccountSectionProps?: Partial<NavAccountSectionProps>
   NotificationsPopover?: FC<NotificationsPopoverProps>

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.5.20",
+  "version": "1.5.21",
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && pnpm relay && tsc --build tsconfig.build.json",


### PR DESCRIPTION
- `__package_name__` package update - `v __package_version__`
  - **changelog_info**
  - **changelog_info**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Headers now support an optional centered content area. Render custom content (e.g., search, branding, or controls) in the header center alongside the account menu.
  * All navigation layouts (centered, horizontal, mini, vertical) forward this center region and preserve account menu alignment so the account area does not shrink when center content is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->