### PR TITLE
fix: richtext identation for lists

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/components
 
+## 1.5.22
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/design-system@1.2.10
+
 ## 1.5.21
 
 ### Patch Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "1.5.21",
+  "version": "1.5.22",
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && pnpm relay && tsc --build tsconfig.build.json",

--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/design-system
 
+## 1.2.10
+
+### Patch Changes
+
+- fix identation for bullet and numbered lists under MarkdownEditorField
+
 ## 1.2.9
 
 ### Patch Changes

--- a/packages/design-system/components/web/inputs/MarkdownEditorField/styled.tsx
+++ b/packages/design-system/components/web/inputs/MarkdownEditorField/styled.tsx
@@ -122,9 +122,11 @@ export const EditorContainer = styled(Box, {
   },
   '& .mdxeditor ol': {
     listStyle: 'decimal inside',
+    paddingInlineStart: theme.spacing(2),
   },
   '& .mdxeditor ul': {
     listStyle: 'inside',
+    paddingInlineStart: theme.spacing(2),
   },
   '& .mdxeditor h2': {
     ...theme.typography.h2,

--- a/packages/design-system/components/web/markdown/Markdown/styled.tsx
+++ b/packages/design-system/components/web/markdown/Markdown/styled.tsx
@@ -87,8 +87,8 @@ export const StyledMarkdown = styled(Box, {
         color: theme.palette.text.disabled,
       },
     },
-    '& ol': { listStyle: 'decimal inside' },
-    '& ul': { listStyle: 'inside' },
+    '& ol': { listStyle: 'decimal inside', paddingInlineStart: theme.spacing(2) },
+    '& ul': { listStyle: 'inside', paddingInlineStart: theme.spacing(2) },
 
     // Blockquote
     '& blockquote': {

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/design-system",
   "description": "Design System components and configurations.",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && tsc --build tsconfig.build.json",

--- a/packages/wagtail/CHANGELOG.md
+++ b/packages/wagtail/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @baseapp-frontend/wagtail
 
+## 1.0.57
+
+### Patch Changes
+
+- Updated dependencies
+  - @baseapp-frontend/design-system@1.2.10
+
 ## 1.0.56
 
 ### Patch Changes

--- a/packages/wagtail/package.json
+++ b/packages/wagtail/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/wagtail",
   "description": "BaseApp Wagtail",
-  "version": "1.0.56",
+  "version": "1.0.57",
   "main": "./index.ts",
   "types": "dist/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
* Add proper identation for bullet and numbered lists inside the MarkdownEditorField

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved left padding for ordered and unordered lists in markdown editors and rendered markdown for clearer indentation and readability.

* **Chores**
  * Updated package versions and corresponding changelogs to record the patch release across relevant packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->