### PR TITLE
BA-3289: RN comments infinite scrolling + scrollable list header

### DIFF
--- a/packages/components/modules/comments/native/CommentItem/index.tsx
+++ b/packages/components/modules/comments/native/CommentItem/index.tsx
@@ -1,4 +1,4 @@
-import { FC, Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react'
+import { FC, Suspense, lazy, useCallback, useEffect, useMemo, useState, useTransition } from 'react'
 
 import { AvatarWithPlaceholder } from '@baseapp-frontend/design-system/components/native/avatars'
 import { Text } from '@baseapp-frontend/design-system/components/native/typographies'
@@ -34,7 +34,7 @@ const CommentItem: FC<CommentItemProps> = ({
 
   const SelectedRepliesList = RepliesList ?? DefaultCommentsList
   const [isRepliesExpanded, setIsRepliesExpanded] = useState(false)
-  const [isLoadingReplies, setIsLoadingReplies] = useState(false)
+  const [isLoadingReplies, startLoadingReplies] = useTransition()
   const [comment, refetch] = useRefetchableFragment<
     CommentItemRefetchQuery,
     CommentItem_comment$key
@@ -52,22 +52,22 @@ const CommentItem: FC<CommentItemProps> = ({
       return
     }
 
-    setIsLoadingReplies(true)
-    refetch(
-      { isRepliesExpanded: true },
-      {
-        fetchPolicy: 'store-or-network',
-        onComplete: (error) => {
-          setIsLoadingReplies(false)
-          if (error) {
-            // eslint-disable-next-line no-console
-            console.error('Error loading replies:', error)
-          } else {
-            setIsRepliesExpanded(true)
-          }
+    startLoadingReplies(() => {
+      refetch(
+        { isRepliesExpanded: true },
+        {
+          fetchPolicy: 'store-or-network',
+          onComplete: (error) => {
+            if (error) {
+              // eslint-disable-next-line no-console
+              console.error('Error loading replies:', error)
+            } else {
+              setIsRepliesExpanded(true)
+            }
+          },
         },
-      },
-    )
+      )
+    })
   }, [isRepliesExpanded, refetch])
 
   const hideReplies = useCallback(() => {
@@ -80,22 +80,22 @@ const CommentItem: FC<CommentItemProps> = ({
 
   useEffect(() => {
     if (commentIdToExpand === comment.id && !isRepliesExpanded && hasReplies) {
-      setIsLoadingReplies(true)
-      refetch(
-        { isRepliesExpanded: true },
-        {
-          fetchPolicy: 'network-only',
-          onComplete: (error) => {
-            setIsLoadingReplies(false)
-            if (error) {
-              // eslint-disable-next-line no-console
-              console.error('Error loading replies:', error)
-            } else {
-              setIsRepliesExpanded(true)
-            }
+      startLoadingReplies(() => {
+        refetch(
+          { isRepliesExpanded: true },
+          {
+            fetchPolicy: 'network-only',
+            onComplete: (error) => {
+              if (error) {
+                // eslint-disable-next-line no-console
+                console.error('Error loading replies:', error)
+              } else {
+                setIsRepliesExpanded(true)
+              }
+            },
           },
-        },
-      )
+        )
+      })
     }
   }, [commentIdToExpand, comment.id, isRepliesExpanded, hasReplies, refetch])
 
@@ -169,6 +169,7 @@ const CommentItem: FC<CommentItemProps> = ({
               <CommentShowRepliesButton
                 onShowReplies={showReplies}
                 totalRepliesCount={comment.commentsCount?.total ?? 0}
+                isLoading={isLoadingReplies}
               />
             )}
           </View>

--- a/packages/components/modules/comments/native/CommentShowRepliesButton/index.tsx
+++ b/packages/components/modules/comments/native/CommentShowRepliesButton/index.tsx
@@ -4,7 +4,7 @@ import { Text } from '@baseapp-frontend/design-system/components/native/typograp
 import { View } from '@baseapp-frontend/design-system/components/native/views'
 import { useTheme } from '@baseapp-frontend/design-system/providers/native'
 
-import { Pressable } from 'react-native'
+import { ActivityIndicator, Pressable } from 'react-native'
 
 import { createStyles } from './styles'
 import { CommentShowRepliesButtonProps } from './types'
@@ -14,17 +14,19 @@ const CommentShowRepliesButton: FC<CommentShowRepliesButtonProps> = ({
   totalRepliesCount,
   body = 'Show replies',
   showTotalRepliesCount = true,
+  isLoading = false,
 }) => {
   const theme = useTheme()
   const styles = createStyles(theme)
 
   return (
     <View style={styles.showRepliesButtonContainer}>
-      <Pressable onPress={onShowReplies} style={styles.showRepliesButton}>
+      <Pressable onPress={onShowReplies} style={styles.showRepliesButton} disabled={isLoading}>
         <Text style={styles.showRepliesButtonText}>
           {body} {showTotalRepliesCount && `(${totalRepliesCount})`}
         </Text>
       </Pressable>
+      {isLoading && <ActivityIndicator size="small" color={theme.colors.object.high} />}
     </View>
   )
 }

--- a/packages/components/modules/comments/native/CommentShowRepliesButton/types.ts
+++ b/packages/components/modules/comments/native/CommentShowRepliesButton/types.ts
@@ -3,4 +3,5 @@ export interface CommentShowRepliesButtonProps {
   totalRepliesCount: number
   body?: string
   showTotalRepliesCount?: boolean
+  isLoading?: boolean
 }

--- a/packages/components/modules/comments/native/Comments/index.tsx
+++ b/packages/components/modules/comments/native/Comments/index.tsx
@@ -16,7 +16,7 @@ import { setFormRelayErrors } from '@baseapp-frontend/utils'
 import { BottomSheetModal } from '@gorhom/bottom-sheet'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
-import { TextInput as NativeTextInput, Pressable } from 'react-native'
+import { TextInput as NativeTextInput, Pressable, ScrollView } from 'react-native'
 import { ConnectionHandler, useFragment } from 'react-relay'
 
 import { CommentItem_comment$data } from '../../../../__generated__/CommentItem_comment.graphql'
@@ -48,6 +48,7 @@ const WithComments: FC<CommentsProps> = ({
   SocialInputDrawerProps = { DrawerProps: {}, PlaceholderProps: {} },
   drawerStyle = {},
   maxThreadDepth = 5,
+  ListHeaderComponent,
 }) => {
   const [isEditMode, setIsEditMode] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
@@ -223,14 +224,19 @@ const WithComments: FC<CommentsProps> = ({
   )
 
   if (!target.isCommentsEnabled) {
-    return <View style={styles.contentContainer}>{children}</View>
+    return (
+      <ScrollView contentContainerStyle={styles.disabledContentContainer}>
+        {ListHeaderComponent}
+        {children}
+      </ScrollView>
+    )
   }
 
   return (
     <>
       <View style={[styles.rootContainer, styles.transparent]}>
         <View style={styles.contentContainer}>
-          <View style={styles.transparent}>{children}</View>
+          {children ? <View style={styles.transparent}>{children}</View> : null}
           <CommentsList
             target={target}
             subscriptionsEnabled={subscriptionsEnabled}
@@ -238,6 +244,7 @@ const WithComments: FC<CommentsProps> = ({
             onLongPress={handleLongPress}
             onReply={handleReply}
             maxThreadDepth={maxThreadDepth}
+            ListHeaderComponent={ListHeaderComponent}
             {...CommentsListProps}
           />
           <SocialInputDrawer.Placeholder

--- a/packages/components/modules/comments/native/Comments/index.tsx
+++ b/packages/components/modules/comments/native/Comments/index.tsx
@@ -16,7 +16,7 @@ import { setFormRelayErrors } from '@baseapp-frontend/utils'
 import { BottomSheetModal } from '@gorhom/bottom-sheet'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
-import { TextInput as NativeTextInput, Pressable, ScrollView } from 'react-native'
+import { TextInput as NativeTextInput, Pressable } from 'react-native'
 import { ConnectionHandler, useFragment } from 'react-relay'
 
 import { CommentItem_comment$data } from '../../../../__generated__/CommentItem_comment.graphql'
@@ -229,7 +229,7 @@ const WithComments: FC<CommentsProps> = ({
   return (
     <>
       <View style={[styles.rootContainer, styles.transparent]}>
-        <ScrollView style={styles.contentContainer}>
+        <View style={styles.contentContainer}>
           <View style={styles.transparent}>{children}</View>
           <CommentsList
             target={target}
@@ -246,7 +246,7 @@ const WithComments: FC<CommentsProps> = ({
             textHeight={textHeight}
             {...SocialInputDrawerProps.PlaceholderProps}
           />
-        </ScrollView>
+        </View>
         <SocialInputDrawer.Drawer
           form={form}
           isLoading={isCreateMutationInFlight || isUpdateMutationInFlight}

--- a/packages/components/modules/comments/native/Comments/styles.ts
+++ b/packages/components/modules/comments/native/Comments/styles.ts
@@ -19,6 +19,9 @@ export const createStyles = (theme: Theme) =>
       flexDirection: 'column',
       flex: 1,
     },
+    disabledContentContainer: {
+      flexGrow: 1,
+    },
     bottomDrawerActionContainer: {
       paddingHorizontal: 16,
       paddingVertical: 12,

--- a/packages/components/modules/comments/native/Comments/styles.ts
+++ b/packages/components/modules/comments/native/Comments/styles.ts
@@ -18,7 +18,6 @@ export const createStyles = (theme: Theme) =>
       display: 'flex',
       flexDirection: 'column',
       flex: 1,
-      paddingHorizontal: 16,
     },
     bottomDrawerActionContainer: {
       paddingHorizontal: 16,

--- a/packages/components/modules/comments/native/Comments/styles.ts
+++ b/packages/components/modules/comments/native/Comments/styles.ts
@@ -21,6 +21,7 @@ export const createStyles = (theme: Theme) =>
     },
     disabledContentContainer: {
       flexGrow: 1,
+      paddingHorizontal: 16,
     },
     bottomDrawerActionContainer: {
       paddingHorizontal: 16,

--- a/packages/components/modules/comments/native/Comments/types.ts
+++ b/packages/components/modules/comments/native/Comments/types.ts
@@ -1,4 +1,4 @@
-import { FC, PropsWithChildren } from 'react'
+import { FC, PropsWithChildren, ReactElement } from 'react'
 
 import { StyleProp, ViewStyle } from 'react-native'
 
@@ -15,4 +15,10 @@ export interface CommentsProps extends PropsWithChildren {
   SocialInputDrawerProps?: SocialInputDrawerProps
   drawerStyle?: StyleProp<ViewStyle>
   maxThreadDepth?: number
+  /**
+   * Content rendered above the comment thread as the scrollable list header (e.g. a page body).
+   * Scrolls together with the comments. When comments are disabled it is rendered inside a
+   * scroll view alongside `children`.
+   */
+  ListHeaderComponent?: ReactElement | null
 }

--- a/packages/components/modules/comments/native/CommentsList/index.tsx
+++ b/packages/components/modules/comments/native/CommentsList/index.tsx
@@ -3,6 +3,9 @@ import { FC, useCallback, useMemo } from 'react'
 import { View } from '@baseapp-frontend/design-system/components/native/views'
 import { useTheme } from '@baseapp-frontend/design-system/providers/native'
 
+import { FlatList } from 'react-native'
+import { ActivityIndicator } from 'react-native-paper'
+
 import { CommentsSubscription, NUMBER_OF_COMMENTS_TO_LOAD_NEXT, useCommentList } from '../../common'
 import CommentShowRepliesButton from '../CommentShowRepliesButton'
 import CommentHideRepliesButton from './CommentHideRepliesButton'
@@ -29,7 +32,7 @@ const CommentsList: FC<CommentsListProps> = ({
   const CommentItemComponent = CommentItem ?? getDefaultCommentItem()
   const theme = useTheme()
   const styles = createStyles(theme)
-  const { data: target, loadNext, hasNext } = useCommentList(targetRef)
+  const { data: target, loadNext, hasNext, isLoadingNext } = useCommentList(targetRef)
   const comments = useMemo(
     () => target?.comments?.edges.filter((edge) => edge?.node).map((edge) => edge?.node) || [],
     [target?.comments?.edges],
@@ -73,12 +76,23 @@ const CommentsList: FC<CommentsListProps> = ({
       {isReplyList && <View style={styles.threadDepthDivider} />}
       <View style={styles.listContainer}>
         {subscriptionsEnabled && <CommentsSubscription targetObjectId={target.id} />}
-        <View style={styles.listContainer} {...CommentsListProps}>
-          {
-            // TODO (another story): paginate properly
-            comments.map((comment) => renderCommentItem(comment))
-          }
-        </View>
+        {isReplyList ? (
+          <View style={styles.listContainer} {...CommentsListProps}>
+            {
+              // TODO (another story): paginate properly
+              comments.map((comment) => renderCommentItem(comment))
+            }
+          </View>
+        ) : (
+          <FlatList
+            contentContainerStyle={{ paddingHorizontal: 16 }}
+            data={comments}
+            renderItem={({ item }) => renderCommentItem(item)}
+            onEndReached={hasNext ? showMoreReplies : undefined}
+            onEndReachedThreshold={0.9}
+            ListFooterComponent={isLoadingNext ? <ActivityIndicator /> : null}
+          />
+        )}
         {shouldShowShowMoreRepliesButton && (
           <CommentShowRepliesButton
             onShowReplies={showMoreReplies}

--- a/packages/components/modules/comments/native/CommentsList/index.tsx
+++ b/packages/components/modules/comments/native/CommentsList/index.tsx
@@ -25,6 +25,7 @@ const CommentsList: FC<CommentsListProps> = ({
   CommentItem,
   CommentItemProps,
   CommentsListProps = {},
+  ListHeaderComponent,
 }) => {
   const CommentItemComponent = CommentItem ?? getDefaultCommentItem()
   const theme = useTheme()
@@ -83,6 +84,7 @@ const CommentsList: FC<CommentsListProps> = ({
         ) : (
           <InfiniteScrollerView
             contentContainerStyle={{ paddingHorizontal: 16 }}
+            ListHeaderComponent={ListHeaderComponent}
             data={comments}
             renderItem={({ item }) => renderCommentItem(item)}
             onEndReached={() => {

--- a/packages/components/modules/comments/native/CommentsList/index.tsx
+++ b/packages/components/modules/comments/native/CommentsList/index.tsx
@@ -101,6 +101,7 @@ const CommentsList: FC<CommentsListProps> = ({
             onShowReplies={showMoreReplies}
             totalRepliesCount={remainingRepliesCount}
             body="Show more replies"
+            isLoading={isLoadingNext}
           />
         )}
         {shouldShowHideRepliesButton && <CommentHideRepliesButton onHideReplies={onHideReplies} />}

--- a/packages/components/modules/comments/native/CommentsList/index.tsx
+++ b/packages/components/modules/comments/native/CommentsList/index.tsx
@@ -1,10 +1,7 @@
 import { FC, useCallback, useMemo } from 'react'
 
-import { View } from '@baseapp-frontend/design-system/components/native/views'
+import { InfiniteScrollerView, View } from '@baseapp-frontend/design-system/components/native/views'
 import { useTheme } from '@baseapp-frontend/design-system/providers/native'
-
-import { FlatList } from 'react-native'
-import { ActivityIndicator } from 'react-native-paper'
 
 import { CommentsSubscription, NUMBER_OF_COMMENTS_TO_LOAD_NEXT, useCommentList } from '../../common'
 import CommentShowRepliesButton from '../CommentShowRepliesButton'
@@ -84,13 +81,17 @@ const CommentsList: FC<CommentsListProps> = ({
             }
           </View>
         ) : (
-          <FlatList
+          <InfiniteScrollerView
             contentContainerStyle={{ paddingHorizontal: 16 }}
             data={comments}
             renderItem={({ item }) => renderCommentItem(item)}
-            onEndReached={hasNext ? showMoreReplies : undefined}
+            onEndReached={() => {
+              if (hasNext) {
+                showMoreReplies()
+              }
+            }}
             onEndReachedThreshold={0.9}
-            ListFooterComponent={isLoadingNext ? <ActivityIndicator /> : null}
+            isLoading={isLoadingNext}
           />
         )}
         {shouldShowShowMoreRepliesButton && (

--- a/packages/components/modules/comments/native/CommentsList/types.ts
+++ b/packages/components/modules/comments/native/CommentsList/types.ts
@@ -1,4 +1,4 @@
-import type { FC } from 'react'
+import type { FC, ReactElement } from 'react'
 
 import type { CommentItem_comment$data } from '../../../../__generated__/CommentItem_comment.graphql'
 import type { CommentsList_comments$key } from '../../../../__generated__/CommentsList_comments.graphql'
@@ -18,4 +18,9 @@ export interface CommentsListProps {
   onHideReplies?: () => void
   currentReplyCount?: number
   maxThreadDepth?: number
+  /**
+   * Rendered above the comments as the top-level list header so it scrolls together with the
+   * thread. Only applied to the root (non-reply) list.
+   */
+  ListHeaderComponent?: ReactElement | null
 }

--- a/packages/components/modules/pages/native/PageComponent/index.tsx
+++ b/packages/components/modules/pages/native/PageComponent/index.tsx
@@ -36,30 +36,32 @@ const PageComponent: FC<PageComponentProps> = ({ page: pageRef }) => {
   }
 
   // A Page implements CommentsInterface, so the page node doubles as the comment thread target.
-  // Comments owns the scroll container and renders this page content (its children) above the
-  // scrollable comment list — so the body is a plain View, not its own ScrollView, and drops the
-  // horizontal padding that Comments' scroll container already applies. When the page has comments
-  // disabled the Comments component renders the children alone, so non-commentable pages are safe.
+  // The page content is the comment list's scrollable header (ListHeaderComponent) so the body and
+  // the thread scroll as one list — the native equivalent of the web page's single-document scroll.
+  // The list applies horizontal padding, so the body here only owns its vertical spacing.
   return (
-    <Comments target={page}>
-      <View style={styles.container}>
-        {!!page.title && (
-          <Text variant="h2" style={styles.title}>
-            {page.title}
-          </Text>
-        )}
-        <RenderHtml
-          contentWidth={width - CONTENT_HORIZONTAL_PADDING * 2}
-          source={{ html: page.body ?? '' }}
-          baseStyle={styles.body}
-          tagsStyles={HTML_TAGS_STYLES}
-          renderersProps={{ a: { onPress: (_event, href) => handleLinkPress(href) } }}
-          // Collapse adjacent vertical margins like the web does (RN otherwise adds them,
-          // doubling the gap between headings and paragraphs).
-          enableExperimentalMarginCollapsing
-        />
-      </View>
-    </Comments>
+    <Comments
+      target={page}
+      ListHeaderComponent={
+        <View style={styles.container}>
+          {!!page.title && (
+            <Text variant="h2" style={styles.title}>
+              {page.title}
+            </Text>
+          )}
+          <RenderHtml
+            contentWidth={width - CONTENT_HORIZONTAL_PADDING * 2}
+            source={{ html: page.body ?? '' }}
+            baseStyle={styles.body}
+            tagsStyles={HTML_TAGS_STYLES}
+            renderersProps={{ a: { onPress: (_event, href) => handleLinkPress(href) } }}
+            // Collapse adjacent vertical margins like the web does (RN otherwise adds them,
+            // doubling the gap between headings and paragraphs).
+            enableExperimentalMarginCollapsing
+          />
+        </View>
+      }
+    />
   )
 }
 


### PR DESCRIPTION
## BA-3289 — React Native comments: infinite scrolling

Merges into the `epic/BA-2239-react-native-comments` epic.

### Changes
- **Infinite scrolling** — the top-level comments thread auto-loads the next page on scroll (`onEndReached` → cursor `loadNext`).
- **`CommentsList` refactor** — replaced `FlatList` with the design-system `InfiniteScrollerView`, so the thread owns a single virtualized scroll container.
- **Scrollable list header** — new `ListHeaderComponent` prop on `Comments`; content above the thread now scrolls *with* the comments instead of sitting in a fixed area.
- **Flat-page integration** — the page body (title + HTML) is passed as that list header, so a flat page and its comment thread scroll as one (the native equivalent of the web page's single-document scroll), and the page margins are restored.
- **Loading states** — "Show replies" runs its refetch inside `useTransition` (so it no longer bubbles up to the flat page's full-screen suspense fallback) and shows a small inline spinner next to the button; the paginated "Show more replies" button shows the same spinner while loading the next page.

### Reply pagination
Nested reply lists render via `.map()` + a manual "Show more replies" (cursor `loadNext`) rather than a nested virtualized list — React Native doesn't allow nesting same-orientation virtualized lists. The underlying pagination is the same `@connection` cursor mechanism as the top-level thread; the `// TODO (another story): paginate properly` note refers to this rendering choice, not missing pagination.

### Touched
`comments/native`: `Comments`, `CommentsList`, `CommentItem`, `CommentShowRepliesButton` · `pages/native/PageComponent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnHQCAMk77oMZkB2J22Rg2
