### PR TITLE
bugfix/BA-3301-fe-multiline-posts-is-showing-in-single-line

### DIFF
--- a/packages/components/modules/content-feed/web/PostForm/index.tsx
+++ b/packages/components/modules/content-feed/web/PostForm/index.tsx
@@ -2,7 +2,7 @@
 
 import { FC } from 'react'
 
-import { TextField } from '@baseapp-frontend/design-system/components/web/inputs'
+import { MarkdownEditorField } from '@baseapp-frontend/design-system/components/web/inputs'
 
 import { LoadingButton } from '@mui/lab'
 import { Box, Button, FormControlLabel, Switch, Typography } from '@mui/material'
@@ -42,12 +42,9 @@ const PostForm: FC<PostFormProps> = ({ form, onSubmit, onCancel, isSaving }) => 
         </HeaderContainer>
         <PostImageDropzone form={form} />
         <Box>
-          <TextField
+          <MarkdownEditorField
             name="content"
-            type="text"
             placeholder="What is on your mind?"
-            multiline
-            rows={4}
             control={form.control}
           />
         </Box>


### PR DESCRIPTION
Wasn't able to reproduce bug, but added Markdown editor as @nossila recommended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Post content editor now features a Markdown editor, enabling users to format text with improved editing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->