### PR TITLE
Use profile path on comments redirect url

### DIFF
--- a/packages/components/modules/comments/web/CommentItem/index.tsx
+++ b/packages/components/modules/comments/web/CommentItem/index.tsx
@@ -4,6 +4,7 @@ import { FC, useRef, useState, useTransition } from 'react'
 
 import { ClickableAvatar } from '@baseapp-frontend/design-system/components/web/avatars'
 import { Markdown } from '@baseapp-frontend/design-system/components/web/markdown'
+import { removeLeadingSlash } from '@baseapp-frontend/utils'
 
 import { Typography } from '@mui/material'
 import Link from 'next/link'
@@ -74,7 +75,9 @@ const CommentItem: FC<CommentItemProps> = ({
 
   const profileUrlPath = comment?.profile?.urlPath?.path
   const profileUrl =
-    !profileUrlPath || useProfileId ? `${profilePath}/${comment?.profile?.id}` : profileUrlPath
+    !profileUrlPath || useProfileId
+      ? `${profilePath}/${comment?.profile?.id}`
+      : `${profilePath}/${removeLeadingSlash(profileUrlPath)}`
   const hasUser = Boolean(comment?.user)
 
   const showReplies = () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profile URL path formatting in comment items to ensure proper path normalization and consistent profile link navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->