### PR TITLE
Make comment item redirect url more flexible

### DIFF
--- a/packages/components/modules/comments/web/CommentItem/index.tsx
+++ b/packages/components/modules/comments/web/CommentItem/index.tsx
@@ -4,6 +4,7 @@ import { FC, useRef, useState, useTransition } from 'react'
 
 import { ClickableAvatar } from '@baseapp-frontend/design-system/components/web/avatars'
 import { Markdown } from '@baseapp-frontend/design-system/components/web/markdown'
+import { removeLeadingSlash } from '@baseapp-frontend/utils'
 
 import { Typography } from '@mui/material'
 import Link from 'next/link'
@@ -44,6 +45,7 @@ const CommentItem: FC<CommentItemProps> = ({
     CommentContainer = DefaultCommentContainer,
     useProfileId = false,
     profilePath = '/profile',
+    prependProfilePath = false,
   }: CustomizableCommentItemProps = customizableProps
 
   const [comment, refetchCommentItem] = useRefetchableFragment<
@@ -73,8 +75,20 @@ const CommentItem: FC<CommentItemProps> = ({
   const [deleteComment, isDeletingComment] = useCommentDeleteMutation()
 
   const profileUrlPath = comment?.profile?.urlPath?.path
-  const profileUrl =
-    !profileUrlPath || useProfileId ? `${profilePath}/${comment?.profile?.id}` : profileUrlPath
+
+  const resolveProfileUrl = () => {
+    if (!profileUrlPath || useProfileId) {
+      return `${profilePath}/${comment?.profile?.id}`
+    }
+    // Opt-in: prefix the url_path with `profilePath` (e.g. `/profile/john-doe`) for apps that
+    // serve profiles under a sub-path. Default keeps the raw url_path for backwards compatibility.
+    if (prependProfilePath) {
+      return `${profilePath}/${removeLeadingSlash(profileUrlPath)}`
+    }
+    return profileUrlPath
+  }
+
+  const profileUrl = resolveProfileUrl()
   const hasUser = Boolean(comment?.user)
 
   const showReplies = () => {

--- a/packages/components/modules/comments/web/CommentItem/types.ts
+++ b/packages/components/modules/comments/web/CommentItem/types.ts
@@ -33,6 +33,7 @@ export type CustomizableCommentItemProps = {
   Timestamp?: FC<TimestampProps>
   useProfileId?: boolean
   profilePath?: string
+  prependProfilePath?: boolean
 }
 
 export interface CommentItemProps extends CustomizableCommentItemProps {


### PR DESCRIPTION
THis PR should not be redirected before Hive baseapp rebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option for comment profiles to build links with an app path prefix when needed.
  * Profile links and avatar navigation now use a more flexible URL format, improving compatibility with different routing setups.

* **Bug Fixes**
  * Improved handling of profile link paths to better support existing and custom link formats without breaking current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->