### PR TITLE
fix: prevent sending messages that contain only whitespace

### DIFF
--- a/.changeset/tidy-spaces-block.md
+++ b/.changeset/tidy-spaces-block.md
@@ -1,5 +1,0 @@
----
-"@baseapp-frontend/components": patch
----
-
-Prevent sending messages that contain only whitespace: reject markdown-escaped whitespace-only bodies (e.g. `&#x20;`) in the social upsert validation schema and run validation on the native MessageCreate submit

--- a/.changeset/tidy-spaces-block.md
+++ b/.changeset/tidy-spaces-block.md
@@ -1,0 +1,5 @@
+---
+"@baseapp-frontend/components": patch
+---
+
+Prevent sending messages that contain only whitespace: reject markdown-escaped whitespace-only bodies (e.g. `&#x20;`) in the social upsert validation schema and run validation on the native MessageCreate submit

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @baseapp-frontend/components
 
+## 2.0.3
+
+### Patch Changes
+
+- 57ab98e: Prevent sending messages that contain only whitespace: reject markdown-escaped whitespace-only bodies (e.g. `&#x20;`) in the social upsert validation schema and run validation on the native MessageCreate submit
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/components/modules/__shared__/common/__tests__/socialUpsertFormValidation.test.ts
+++ b/packages/components/modules/__shared__/common/__tests__/socialUpsertFormValidation.test.ts
@@ -1,0 +1,46 @@
+import { SOCIAL_UPSERT_FORM_VALIDATION_SCHEMA } from '../constants'
+import { hasVisibleContent } from '../utils'
+
+const parseBody = (body: string) =>
+  SOCIAL_UPSERT_FORM_VALIDATION_SCHEMA.safeParse({ body, mentionedProfileIds: [] })
+
+describe('hasVisibleContent', () => {
+  it('returns false for whitespace-only content', () => {
+    expect(hasVisibleContent('')).toBe(false)
+    expect(hasVisibleContent('   ')).toBe(false)
+    expect(hasVisibleContent('\n\t ')).toBe(false)
+  })
+
+  it('returns false for markdown-escaped whitespace-only content', () => {
+    expect(hasVisibleContent('&#x20;')).toBe(false)
+    expect(hasVisibleContent('&#x20; &#x20;')).toBe(false)
+    expect(hasVisibleContent('&#32;')).toBe(false)
+    expect(hasVisibleContent('&nbsp;')).toBe(false)
+  })
+
+  it('returns true for content with visible characters', () => {
+    expect(hasVisibleContent('hello')).toBe(true)
+    expect(hasVisibleContent('&#x20;hello&#x20;')).toBe(true)
+  })
+})
+
+describe('SOCIAL_UPSERT_FORM_VALIDATION_SCHEMA', () => {
+  it('rejects empty and whitespace-only bodies', () => {
+    expect(parseBody('').success).toBe(false)
+    expect(parseBody('   ').success).toBe(false)
+  })
+
+  it('rejects bodies that only contain markdown-escaped whitespace', () => {
+    expect(parseBody('&#x20;').success).toBe(false)
+    expect(parseBody('&#x20; &#x20;').success).toBe(false)
+  })
+
+  it('accepts bodies with visible content', () => {
+    expect(parseBody('hello').success).toBe(true)
+    expect(parseBody('&#x20;hello').success).toBe(true)
+  })
+
+  it('rejects bodies over 1000 characters', () => {
+    expect(parseBody('a'.repeat(1001)).success).toBe(false)
+  })
+})

--- a/packages/components/modules/__shared__/common/constants.ts
+++ b/packages/components/modules/__shared__/common/constants.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { SocialUpsertForm } from './types'
+import { hasVisibleContent } from './utils'
 
 export const DEFAULT_SOCIAL_UPSERT_FORM_VALUES: SocialUpsertForm = {
   body: '',
@@ -17,6 +18,7 @@ export const SOCIAL_UPSERT_FORM_VALIDATION_SCHEMA = z.object({
     .string()
     .trim()
     .min(1, { message: 'Must have at least one character' })
-    .max(1000, { message: 'Must have at most 1000 characters' }),
+    .max(1000, { message: 'Must have at most 1000 characters' })
+    .refine(hasVisibleContent, { message: 'Must have at least one character' }),
   mentionedProfileIds: z.array(z.string()),
 })

--- a/packages/components/modules/__shared__/common/utils.ts
+++ b/packages/components/modules/__shared__/common/utils.ts
@@ -1,3 +1,11 @@
+// The markdown editor serializes leading/trailing spaces as character
+// references (e.g. `&#x20;`), so a whitespace-only input survives `.trim()`.
+const MARKDOWN_ESCAPED_WHITESPACE_REGEX = /&#x20;|&#32;|&nbsp;/gi
+
+export function hasVisibleContent(body: string): boolean {
+  return body.replace(MARKDOWN_ESCAPED_WHITESPACE_REGEX, ' ').trim().length > 0
+}
+
 export function formatHandle(path?: string): string | null {
   if (!path) return null
   return `@${path.replace('/', '')}`

--- a/packages/components/modules/messages/native/MessageCreate/index.tsx
+++ b/packages/components/modules/messages/native/MessageCreate/index.tsx
@@ -12,7 +12,6 @@ import { ConnectionHandler } from 'react-relay'
 import { SocialUpsertForm } from '../../../__shared__/common'
 import {
   DEFAULT_SOCIAL_UPSERT_FORM_VALUES,
-  SOCIAL_UPSERT_FORM,
   SOCIAL_UPSERT_FORM_VALIDATION_SCHEMA,
 } from '../../../__shared__/common/constants'
 import DefaultSocialInputDrawer from '../SocialInputDrawer'
@@ -38,7 +37,6 @@ const MessageCreate = forwardRef<NativeTextInput, CommentCreateProps>(
       resolver: zodResolver(SOCIAL_UPSERT_FORM_VALIDATION_SCHEMA),
     })
     const [commitMutation, isMutationInFlight] = useSendMessageMutation()
-    const body = form.watch(SOCIAL_UPSERT_FORM.body)
 
     const { onFocusChange, textHeight, onTextHeightChange, keyboardHeight } =
       SocialInputDrawer.useTextInputProperties()
@@ -47,14 +45,14 @@ const MessageCreate = forwardRef<NativeTextInput, CommentCreateProps>(
       return null
     }
 
-    const onSubmit = () => {
+    const onSubmit = (data: SocialUpsertForm) => {
       if (isMutationInFlight || !currentProfile) return
 
       nextClientMutationId += 1
       const clientMutationId = nextClientMutationId.toString()
 
       const connectionID = ConnectionHandler.getConnectionID(targetObjectId, 'chatRoom_allMessages')
-      const content = body
+      const content = data.body
 
       commitMutation({
         variables: {
@@ -121,7 +119,7 @@ const MessageCreate = forwardRef<NativeTextInput, CommentCreateProps>(
           showHandle={showHandle}
           ref={ref}
           style={drawerStyle}
-          submit={onSubmit}
+          submit={form.handleSubmit(onSubmit)}
           {...SocialInputDrawerProps.DrawerProps}
         />
       </>

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@baseapp-frontend/components",
   "description": "BaseApp components modules such as comments, notifications, messages, and more.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && pnpm relay && tsc --build tsconfig.build.json",


### PR DESCRIPTION
## Summary

Users could send a message containing only spaces, which appeared as a blank bubble in the conversation thread.

### Root cause

- **Web**: the message input is an MDXEditor (markdown). A spaces-only input is serialized with markdown character references (e.g. `&#x20;`), which survive the schema's `.trim().min(1)` check — so the send button enabled and the "blank" message was sent.
- **Native**: `MessageCreate` invoked its submit handler directly with a `form.watch` value, bypassing zod validation entirely.

### Fix

- Add `hasVisibleContent` (treats `&#x20;`/`&#32;`/`&nbsp;` as whitespace) and use it as a `.refine` on `SOCIAL_UPSERT_FORM_VALIDATION_SCHEMA`. This disables the send button for whitespace-only input and blocks submission on web and native (and any other consumer of the shared schema, e.g. message edit and comments).
- Route the native `MessageCreate` submit through `form.handleSubmit(onSubmit)` so validation runs at submit time.

### Tests

- New unit tests for `hasVisibleContent` and the schema (`packages/components/modules/__shared__/common/__tests__/socialUpsertFormValidation.test.ts`) — 7 tests passing; full components unit suite green.
- Typecheck (`tsc --noEmit`) and eslint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHvCU8JqgykLGxNL3FSTFh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented messages containing only spaces or markdown-escaped whitespace from being submitted.
  * Message creation now applies form validation before submission.
  * Continued to enforce the 1,000-character message limit.

* **Tests**
  * Added coverage for whitespace-only content, visible text, escaped whitespace, and length validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->