### PR TITLE
fix: prevent sending messages that contain only whitespace (epic integration)

### DIFF
--- a/.changeset/tidy-spaces-block.md
+++ b/.changeset/tidy-spaces-block.md
@@ -1,0 +1,5 @@
+---
+"@baseapp-frontend/components": patch
+---
+
+Prevent sending messages that contain only whitespace: reject markdown-escaped whitespace-only bodies (e.g. `&#x20;`) in the social upsert validation schema and run validation on the native MessageCreate submit

--- a/packages/components/modules/__shared__/common/__tests__/socialUpsertFormValidation.test.ts
+++ b/packages/components/modules/__shared__/common/__tests__/socialUpsertFormValidation.test.ts
@@ -1,0 +1,46 @@
+import { SOCIAL_UPSERT_FORM_VALIDATION_SCHEMA } from '../constants'
+import { hasVisibleContent } from '../utils'
+
+const parseBody = (body: string) =>
+  SOCIAL_UPSERT_FORM_VALIDATION_SCHEMA.safeParse({ body, mentionedProfileIds: [] })
+
+describe('hasVisibleContent', () => {
+  it('returns false for whitespace-only content', () => {
+    expect(hasVisibleContent('')).toBe(false)
+    expect(hasVisibleContent('   ')).toBe(false)
+    expect(hasVisibleContent('\n\t ')).toBe(false)
+  })
+
+  it('returns false for markdown-escaped whitespace-only content', () => {
+    expect(hasVisibleContent('&#x20;')).toBe(false)
+    expect(hasVisibleContent('&#x20; &#x20;')).toBe(false)
+    expect(hasVisibleContent('&#32;')).toBe(false)
+    expect(hasVisibleContent('&nbsp;')).toBe(false)
+  })
+
+  it('returns true for content with visible characters', () => {
+    expect(hasVisibleContent('hello')).toBe(true)
+    expect(hasVisibleContent('&#x20;hello&#x20;')).toBe(true)
+  })
+})
+
+describe('SOCIAL_UPSERT_FORM_VALIDATION_SCHEMA', () => {
+  it('rejects empty and whitespace-only bodies', () => {
+    expect(parseBody('').success).toBe(false)
+    expect(parseBody('   ').success).toBe(false)
+  })
+
+  it('rejects bodies that only contain markdown-escaped whitespace', () => {
+    expect(parseBody('&#x20;').success).toBe(false)
+    expect(parseBody('&#x20; &#x20;').success).toBe(false)
+  })
+
+  it('accepts bodies with visible content', () => {
+    expect(parseBody('hello').success).toBe(true)
+    expect(parseBody('&#x20;hello').success).toBe(true)
+  })
+
+  it('rejects bodies over 1000 characters', () => {
+    expect(parseBody('a'.repeat(1001)).success).toBe(false)
+  })
+})

--- a/packages/components/modules/__shared__/common/constants.ts
+++ b/packages/components/modules/__shared__/common/constants.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { SocialUpsertForm } from './types'
+import { hasVisibleContent } from './utils'
 
 export const DEFAULT_SOCIAL_UPSERT_FORM_VALUES: SocialUpsertForm = {
   body: '',
@@ -19,7 +20,8 @@ export const SOCIAL_UPSERT_FORM_VALIDATION_SCHEMA = z.object({
     .string()
     .trim()
     .min(1, { message: 'Must have at least one character' })
-    .max(1000, { message: 'Must have at most 1000 characters' }),
+    .max(1000, { message: 'Must have at most 1000 characters' })
+    .refine(hasVisibleContent, { message: 'Must have at least one character' }),
   mentionedProfileIds: z.array(z.string()),
   id: z.string().optional(),
 })

--- a/packages/components/modules/__shared__/common/utils.ts
+++ b/packages/components/modules/__shared__/common/utils.ts
@@ -1,3 +1,11 @@
+// The markdown editor serializes leading/trailing spaces as character
+// references (e.g. `&#x20;`), so a whitespace-only input survives `.trim()`.
+const MARKDOWN_ESCAPED_WHITESPACE_REGEX = /&#x20;|&#32;|&nbsp;/gi
+
+export function hasVisibleContent(body: string): boolean {
+  return body.replace(MARKDOWN_ESCAPED_WHITESPACE_REGEX, ' ').trim().length > 0
+}
+
 export function formatHandle(path?: string): string | null {
   if (!path) return null
   return `@${path.replace('/', '')}`

--- a/packages/components/modules/messages/native/MessageCreate/index.tsx
+++ b/packages/components/modules/messages/native/MessageCreate/index.tsx
@@ -12,7 +12,6 @@ import { ConnectionHandler } from 'react-relay'
 import { SocialUpsertForm } from '../../../__shared__/common'
 import {
   DEFAULT_SOCIAL_UPSERT_FORM_VALUES,
-  SOCIAL_UPSERT_FORM,
   SOCIAL_UPSERT_FORM_VALIDATION_SCHEMA,
 } from '../../../__shared__/common/constants'
 import DefaultSocialInputDrawer from '../SocialInputDrawer'
@@ -38,7 +37,6 @@ const MessageCreate = forwardRef<NativeTextInput, CommentCreateProps>(
       resolver: zodResolver(SOCIAL_UPSERT_FORM_VALIDATION_SCHEMA),
     })
     const [commitMutation, isMutationInFlight] = useSendMessageMutation()
-    const body = form.watch(SOCIAL_UPSERT_FORM.body)
 
     const { onFocusChange, textHeight, onTextHeightChange, keyboardHeight } =
       SocialInputDrawer.useTextInputProperties()
@@ -47,14 +45,14 @@ const MessageCreate = forwardRef<NativeTextInput, CommentCreateProps>(
       return null
     }
 
-    const onSubmit = () => {
-      if (isMutationInFlight || !currentProfile || !body) return
+    const onSubmit = (data: SocialUpsertForm) => {
+      if (isMutationInFlight || !currentProfile) return
 
       nextClientMutationId += 1
       const clientMutationId = nextClientMutationId.toString()
 
       const connectionID = ConnectionHandler.getConnectionID(targetObjectId, 'chatRoom_allMessages')
-      const content = body
+      const content = data.body
 
       commitMutation({
         variables: {
@@ -116,7 +114,7 @@ const MessageCreate = forwardRef<NativeTextInput, CommentCreateProps>(
           showHandle={showHandle}
           ref={ref}
           style={drawerStyle}
-          submit={onSubmit}
+          submit={form.handleSubmit(onSubmit)}
           {...SocialInputDrawerProps.DrawerProps}
         />
       </>


### PR DESCRIPTION
## Summary

Epic-integration variant of #406 — the same whitespace-only message fix rebased onto `epic/BA-2239-react-native-comments` as a single commit, so the epic ships with it.

Users could send a message containing only spaces, which appeared as a blank bubble in the conversation thread.

### Root cause

- **Web**: the message input is an MDXEditor (markdown). A spaces-only input is serialized with markdown character references (e.g. `&#x20;`), which survive the schema's `.trim().min(1)` check — so the send button enabled and the "blank" message was sent.
- **Native**: `MessageCreate` invoked its submit handler directly with a `form.watch` value, bypassing zod validation entirely.

### Fix

- Add `hasVisibleContent` (treats `&#x20;`/`&#32;`/`&nbsp;` as whitespace) and use it as a `.refine` on `SOCIAL_UPSERT_FORM_VALIDATION_SCHEMA`. This disables the send button and blocks submission for whitespace-only input on web and native — including the epic's new native comment composer, which shares the schema.
- Route the native `MessageCreate` submit through `form.handleSubmit(onSubmit)` so validation runs at submit time (subsumes the epic's `!body` guard).

### Tests

- New unit tests for `hasVisibleContent` and the schema — full components unit suite green (18/18 on the merged tree), `tsc --noEmit` and eslint clean.

### Relationship to #406

#406 delivers the same fix straight to `master`. This PR delivers it to the epic so the epic branch doesn't regress it; whichever merges second will see the changes already applied (identical content, conflict-free or empty diff after the other lands).

### Note for epic owners

The epic's new shared-native `useCommentComposer` still calls submit directly with a watched value (same pattern messages had). The schema refine keeps its send button disabled for whitespace-only input, but you may want the same `form.handleSubmit` treatment there for defense in depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHvCU8JqgykLGxNL3FSTFh