### PR TITLE
hotfix: stale data after client side navigation

### DIFF
--- a/.changeset/stale-preloaded-query-replay.md
+++ b/.changeset/stale-preloaded-query-replay.md
@@ -1,0 +1,5 @@
+---
+'@baseapp-frontend/graphql': patch
+---
+
+Fix stale data overwriting fresh mutation results after client-side navigation. `useSerializablePreloadedQuery` re-wrote the SSR-serialized query response into the `QueryResponseCache` on every mount, and the `store-and-network` fetch policy then committed it to the Relay store. In production, Next.js can re-deliver an old RSC payload (client router cache on back/forward navigation, prefetch entries), so a response fetched before a mutation would clobber the fields the mutation had just updated — e.g. editing the profile headline and still seeing the old value until a hard refresh. Serialized payloads now carry a `fetchedAt` timestamp and are only replayed while younger than the response-cache TTL; older payloads are skipped so the page renders from the store and revalidates over the network.

--- a/packages/graphql/config/environment.ts
+++ b/packages/graphql/config/environment.ts
@@ -25,7 +25,7 @@ import RelayDefaultHandlerProvider, {
   HandlerProvider,
 } from 'relay-runtime/lib/handlers/RelayDefaultHandlerProvider'
 
-const CACHE_TTL = 5 * 1000 // 5 seconds, to resolve preloaded results
+export const CACHE_TTL = 5 * 1000 // 5 seconds, to resolve preloaded results
 
 const MAX_WS_RETRY_ATTEMPTS = 10
 const BASE_WS_RETRY_DELAY_IN_MS = 1000

--- a/packages/graphql/config/loadSerializableQuery.ts
+++ b/packages/graphql/config/loadSerializableQuery.ts
@@ -10,6 +10,9 @@ export interface SerializablePreloadedQuery<
   params: TRequest['params']
   variables: VariablesOf<TQuery>
   response: GraphQLResponse
+  // Epoch ms of the server-side fetch. Lets the client detect and skip replaying
+  // payloads re-delivered later from Next.js router/prefetch caches.
+  fetchedAt: number
 }
 
 // Call into raw network fetch to get serializable GraphQL query response
@@ -27,5 +30,6 @@ export default async function loadSerializableQuery<
     params,
     variables,
     response,
+    fetchedAt: Date.now(),
   }
 }

--- a/packages/graphql/config/useSerializablePreloadedQuery.ts
+++ b/packages/graphql/config/useSerializablePreloadedQuery.ts
@@ -7,13 +7,26 @@ import { useMemo } from 'react'
 import { PreloadFetchPolicy, PreloadedQuery } from 'react-relay'
 import { ConcreteRequest, Environment, OperationType } from 'relay-runtime'
 
-import { getCacheByEnvironment } from './environment'
+import { CACHE_TTL, getCacheByEnvironment } from './environment'
 import { SerializablePreloadedQuery } from './loadSerializableQuery'
+
+// Next.js can re-deliver an old RSC payload (client router cache on back/forward
+// navigation, prefetch entries). Replaying its embedded query response would
+// overwrite newer store data — e.g. fields just changed by a mutation — so only
+// responses younger than the response cache TTL are written. Skipping the write
+// makes `store-and-network` fall through to a real network fetch instead.
+// A missing `fetchedAt` (payload serialized by an older server build) is treated
+// as fresh to keep rolling deploys safe.
+function isStalePreloadedQuery(fetchedAt: number | undefined): boolean {
+  return fetchedAt != null && Date.now() - fetchedAt > CACHE_TTL
+}
 
 function writePreloadedQueryToCache<TRequest extends ConcreteRequest, TQuery extends OperationType>(
   preloadedQueryObject: SerializablePreloadedQuery<TRequest, TQuery>,
   environment: Environment,
 ) {
+  if (isStalePreloadedQuery(preloadedQueryObject.fetchedAt)) return
+
   const cacheKey = preloadedQueryObject.params.id ?? preloadedQueryObject.params.cacheID
   const responseCache = getCacheByEnvironment(environment)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale preloaded query results from overwriting newer data.
  * Ensured older cached responses are skipped while current store data remains available.
  * Enabled network revalidation to refresh data without replacing fresh mutation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->