### PR TITLE
fix: bump brace-expansion overrides to patch CVE-2026-69152

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
   "pnpm": {
     "overrides": {
       "@xmldom/xmldom": ">=0.9.10",
-      "brace-expansion@^1.0.0": ">=2.1.3 <3",
-      "brace-expansion@^2.0.0": ">=2.1.3 <3",
-      "brace-expansion@^5.0.0": ">=5.0.8",
+      "brace-expansion@^1.0.0": ">=2.1.4 <3",
+      "brace-expansion@^2.0.0": ">=2.1.4 <3",
+      "brace-expansion@^5.0.0": ">=5.0.9",
       "esbuild": ">=0.28.1",
       "form-data": ">=4.0.6",
       "js-yaml": ">=4.3.0 <5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,9 +499,9 @@ overrides:
   wrap-ansi: 7.0.0
   string-width: 4.1.0
   '@xmldom/xmldom': '>=0.9.10'
-  brace-expansion@^1.0.0: '>=2.1.3 <3'
-  brace-expansion@^2.0.0: '>=2.1.3 <3'
-  brace-expansion@^5.0.0: '>=5.0.8'
+  brace-expansion@^1.0.0: '>=2.1.4 <3'
+  brace-expansion@^2.0.0: '>=2.1.4 <3'
+  brace-expansion@^5.0.0: '>=5.0.9'
   esbuild: '>=0.28.1'
   form-data: '>=4.0.6'
   js-yaml: '>=4.3.0 <5'
@@ -6226,11 +6226,11 @@ packages:
     resolution: {integrity: sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==}
     engines: {node: '>= 5.10.0'}
 
-  brace-expansion@2.1.3:
-    resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -18305,11 +18305,11 @@ snapshots:
     dependencies:
       big-integer: 1.6.52
 
-  brace-expansion@2.1.3:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -22943,15 +22943,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 2.1.3
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.3
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
Trivy flags brace-expansion 2.1.3 and 5.0.8 (HIGH, DoS via unbounded intermediate arrays). Fixed in 2.1.4 / 5.0.9 — move the existing overrides up one patch each.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version requirements to use newer minimum versions for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->